### PR TITLE
.gitignore and lint line-length fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,8 @@
 {
   "line_length": {
     "line_length": 120,
-    "strict": true,
+    "strict": false,
+    "stern": true,
     "code_blocks": false,
     "tables": false,
   }


### PR DESCRIPTION
Updated the lint rules to use `stern: true` instead of `strict: true` option for `MD013 - Line length`. I.e. only warn about line-length when there is white-space after the limit. Long URLs are not a problem.

And also added a `.gitignore` to not depend on global user gitignore for ignoring `node_modules` when installing/running the linter locally.
