### PR TITLE
Rollup node spec fixes

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -137,9 +137,7 @@ passed to the [execution engine] to construct L2 blocks.
 "Payload attributes" is a term that originates and is specified in the [Ethereum Engine API specification][engine-api],
 which we extend in this specification.
 
-cf. [Execution Engine Specification](TODO)
-
-> **TODO LINK** execution engine specification
+cf. [Execution Engine Specification](exec-engine.md)
 
 Payload attributes were historically called "L2 block inputs" in the L2 spec and you might still hear some people using
 this term.
@@ -196,9 +194,7 @@ Advanced note: the deposits are not stored in calldata because they can be send 
 is part of the execution, but its value is not captured in one of the [Merkle roots][Merkle root] included in the L1
 block.
 
-cf. [Deposit Feed Contract Specification](TODO)
-
-> **TODO LINK** deposit feed contract specification
+cf. [Deposits Specification](deposits.md)
 
 ------------------------------------------------------------------------------------------------------------------------
 

--- a/rollup-node.md
+++ b/rollup-node.md
@@ -94,7 +94,7 @@ The type notation used here refers to the [HEX value encoding] used by the [Ethe
 specification][JSON-RPC-API], as this structure will need to be sent over JSON-RPC. `array` refers to a JSON array.
 
 [HEX value encoding]: https://eth.wiki/json-rpc/API#hex-value-encoding
-[JSON-RPC-API]: https://eth.wiki/json-rpc/API
+[JSON-RPC-API]: https://github.com/ethereum/execution-apis
 
 The object properties must be set as follows:
 

--- a/rollup-node.md
+++ b/rollup-node.md
@@ -63,8 +63,7 @@ The rollup reads the following data from each L1 block:
 
 [random]: https://eips.ethereum.org/EIPS/eip-4399
 
-A deposit is an L2 transaction that has been submitted on L1, via a call sent to the [deposit feed
-contract][deposit-feed].
+A deposit is an L2 transaction that has been submitted on L1, via a call to the [deposit feed contract][deposit-feed].
 
 While deposits are notably (but not only) used to "deposit" (bridge) ETH and tokens to L2, the word *deposit* should be
 understood as "a transaction *deposited* to L2".
@@ -72,11 +71,9 @@ understood as "a transaction *deposited* to L2".
 The L1 attributes are read from the L1 block header, while deposits are read from the block's [receipts]. Refer to the
 [**deposit feed contract specification**][deposit-feed] for details on how deposits are encoded as log entries.
 
-[deposit-feed-spec]: TODO
+[deposit-feed-spec]: deposits.md
 
-> **TODO LINK** deposit feed contract specification
-
-From the data read from , the rollup node constructs an expanded version of the [Engine API PayloadAttributesV1
+From the data read from L1, the rollup node constructs an expanded version of the [Engine API PayloadAttributesV1
 object][PayloadAttributesV1]:
 
 [PayloadAttributesV1]: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#payloadattributesv1

--- a/rollup-node.md
+++ b/rollup-node.md
@@ -248,7 +248,7 @@ the descendant of an ancestor of the previous head). In those case, the rollup d
 2. If the call returns `"SUCCESS"`, we are done: the execution engine retrieved all the new L2 blocks via [block sync].
 3. Otherwise the call returns `"SYNCING"`, and we must derive the new blocks ourselves. Start by locating the *common
    ancestor*, a block that is an ancestor of both the previous and new head.
-4. Isolate the range of L1 blocks `]common ancestor, ..., new head]`.
+4. Isolate the range of L1 blocks from `common ancestor` (excluded) to `new head` (included).
 5. For each such block, call [`engine_forkchoiceUpdatedOPV1`], [`engine_getPayloadV1`], and [`engine_executePayloadV1`].
    - Fill the [`PayloadAttributesOPV1`] object according to [the section on payload attributes][payload-attr].
    - Fill the [`ForkchoiceStateV1`] object according to [the section on the execution engine][calling-exec-engine], but


### PR DESCRIPTION
- Addresses https://github.com/ethereum-optimism/optimistic-specs/issues/47 (specify errors)
- Explains sync better.
- Add links to new specification files.