### PR TITLE
ci: golang linting and testing

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,29 @@
+name: Go lint and test
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'staging'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.43.0  # version of golangci-lint, not the action
+          skip-go-installation: true
+          # rules: https://golangci-lint.run/usage/quick-start/
+          args: -E asciicheck,goimports
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'staging'
   pull_request:
   workflow_dispatch:
 

--- a/meta/linting.md
+++ b/meta/linting.md
@@ -1,5 +1,7 @@
 # Linting
 
+## Markdown
+
 See
 
 - [markdownlint rule reference](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
@@ -11,3 +13,28 @@ Justification for linting rules in [.markdownlint.json](/.markdownlint.json):
 - *no-blanks-blockquote*: enable multiple consecutive blockquotes separated by white lines
 - *single-title*: enable reusing `<h1>` for content
 - *no-emphasis-as-heading*: enable emphasized paragraphs
+
+```shell
+yarn           # Install dependencies
+yarn lint      # Run linter
+```
+
+## Go
+
+See
+
+- [golangci-lint docs](https://golangci-lint.run/usage/install/#local-installation)
+- [golangci-lint github](https://github.com/golangci/golangci-lint)
+- [github action github](https://github.com/golangci/golangci-lint-action)
+
+Justification for linting rules:
+
+- *asciicheck*: no symbol names with invisible unicode and such
+- *goimports*: group local and external import
+
+```shell
+# Install linter globally (should not affect go.mod)
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+# run linter, add --fix option to fix problems (where supported)
+golangci-lint run -E asciicheck,goimports
+```

--- a/opnode/node/driver.go
+++ b/opnode/node/driver.go
@@ -71,10 +71,11 @@ func Derive(input InputItem) (out OutputItem) {
 					continue
 				}
 				out.UserDepositTxs = append(out.UserDepositTxs, &tx)
-			} else {
-				// TODO: logs from other addresses may still be converted to other types of deposit txs,
-				// if we implement payment for this type of L1 -> L2 subscription service.
 			}
+			//else {
+			// TODO: logs from other addresses may still be converted to other types of deposit txs,
+			// if we implement payment for this type of L1 -> L2 subscription service.
+			//}
 		}
 	}
 	return

--- a/opnode/node/log.go
+++ b/opnode/node/log.go
@@ -2,10 +2,10 @@ package node
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/log"
 	"os"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/log"
 	"golang.org/x/term"
 )
 
@@ -49,12 +49,11 @@ func (lf LogFormat) String() string {
 func (lf *LogFormat) Set(v string) error {
 	switch v {
 	case "json", "json-pretty", "terminal", "text":
+		*lf = LogFormat(v)
 		return nil
 	default:
 		return fmt.Errorf("unrecognized log format: %s", v)
 	}
-	*lf = LogFormat(v)
-	return nil
 }
 
 func (lf *LogFormat) Type() string {

--- a/opnode/node/node.go
+++ b/opnode/node/node.go
@@ -2,8 +2,9 @@ package node
 
 import (
 	"context"
-	"github.com/ethereum/go-ethereum/rpc"
 	"time"
+
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 type OpNodeCmd struct {


### PR DESCRIPTION
Changes:
- Run linting on `staging` branch
- Go linting in CI
- Go test in CI
- Update linting meta doc how to run Go linter locally
- Fix go code: fix dead return statements, single-case select, empty else.

Edit (force push): forgot goimports in CI config


