### PR TITLE
Split 'value' into 'mint' and 'value'

### DIFF
--- a/packages/contracts/contracts/L1/DepositFeed.sol
+++ b/packages/contracts/contracts/L1/DepositFeed.sol
@@ -14,8 +14,8 @@ contract DepositFeed {
     event TransactionDeposited(
         address indexed from,
         address indexed to,
-        uint256 depositValue,
-        uint256 sendValue,
+        uint256 mint,
+        uint256 value,
         uint256 gasLimit,
         bool isCreation,
         bytes data
@@ -25,14 +25,14 @@ contract DepositFeed {
      * Accepts deposits of ETH and data, and emits a TransactionDeposited event for use in deriving
      * deposit transactions.
      * @param _to The L2 destination address.
-     * @param _sendValue The ETH value to send in the deposit transaction.
+     * @param _value The ETH value to send in the deposit transaction.
      * @param _gasLimit The L2 gasLimit.
      * @param _isCreation Whether or not the transaction should be contract creation.
      * @param _data The input data.
      */
     function depositTransaction(
         address _to,
-        uint256 _sendValue,
+        uint256 _value,
         uint256 _gasLimit,
         bool _isCreation,
         bytes memory _data
@@ -49,6 +49,6 @@ contract DepositFeed {
             }
         }
 
-        emit TransactionDeposited(from, _to, msg.value, _sendValue, _gasLimit, _isCreation, _data);
+        emit TransactionDeposited(from, _to, msg.value, _value, _gasLimit, _isCreation, _data);
     }
 }

--- a/packages/contracts/contracts/L1/DepositFeed.sol
+++ b/packages/contracts/contracts/L1/DepositFeed.sol
@@ -14,7 +14,8 @@ contract DepositFeed {
     event TransactionDeposited(
         address indexed from,
         address indexed to,
-        uint256 value,
+        uint256 depositValue,
+        uint256 sendValue,
         uint256 gasLimit,
         bool isCreation,
         bytes data
@@ -24,12 +25,14 @@ contract DepositFeed {
      * Accepts deposits of ETH and data, and emits a TransactionDeposited event for use in deriving
      * deposit transactions.
      * @param _to The L2 destination address.
+     * @param _sendValue The ETH value to send in the deposit transaction.
      * @param _gasLimit The L2 gasLimit.
      * @param _isCreation Whether or not the transaction should be contract creation.
      * @param _data The input data.
      */
     function depositTransaction(
         address _to,
+        uint256 _sendValue,
         uint256 _gasLimit,
         bool _isCreation,
         bytes memory _data
@@ -46,6 +49,6 @@ contract DepositFeed {
             }
         }
 
-        emit TransactionDeposited(from, _to, msg.value, _gasLimit, _isCreation, _data);
+        emit TransactionDeposited(from, _to, msg.value, _sendValue, _gasLimit, _isCreation, _data);
     }
 }

--- a/packages/contracts/test/L1/DepositFeed.spec.ts
+++ b/packages/contracts/test/L1/DepositFeed.spec.ts
@@ -17,7 +17,8 @@ const decodeDepositEvent = async (
 ): Promise<{
   from: string
   to: string
-  value: BigNumber
+  depositValue: BigNumber
+  sendValue: BigNumber
   gasLimit: BigNumber
   isCreation: boolean
   data: string
@@ -30,7 +31,8 @@ const decodeDepositEvent = async (
   return {
     from: eventArgs.from,
     to: eventArgs.to,
-    value: eventArgs.value,
+    depositValue: eventArgs.depositValue,
+    sendValue: eventArgs.sendValue,
     gasLimit: eventArgs.gasLimit,
     isCreation: eventArgs.isCreation,
     data: eventArgs.data,
@@ -51,6 +53,7 @@ describe('DepositFeed', () => {
     await expect(
       depositFeed.depositTransaction(
         NON_ZERO_ADDRESS,
+        NON_ZERO_VALUE,
         NON_ZERO_GASLIMIT,
         true,
         '0x'
@@ -64,6 +67,7 @@ describe('DepositFeed', () => {
     it('when an EOA deposits a transaction with 0 value.', async () => {
       await depositFeed.depositTransaction(
         ZERO_ADDRESS,
+        ZERO_BIGNUMBER,
         NON_ZERO_GASLIMIT,
         false,
         NON_ZERO_DATA
@@ -74,7 +78,8 @@ describe('DepositFeed', () => {
       expect(eventArgs).to.deep.equal({
         from: signerAddress,
         to: ZERO_ADDRESS,
-        value: ZERO_BIGNUMBER,
+        depositValue: ZERO_BIGNUMBER,
+        sendValue: ZERO_BIGNUMBER,
         gasLimit: NON_ZERO_GASLIMIT,
         isCreation: false,
         data: NON_ZERO_DATA,
@@ -84,6 +89,7 @@ describe('DepositFeed', () => {
     it('when an EOA deposits a contract creation with 0 value.', async () => {
       await depositFeed.depositTransaction(
         ZERO_ADDRESS,
+        ZERO_BIGNUMBER,
         NON_ZERO_GASLIMIT,
         true,
         NON_ZERO_DATA
@@ -94,7 +100,8 @@ describe('DepositFeed', () => {
       expect(eventArgs).to.deep.equal({
         from: signerAddress,
         to: ZERO_ADDRESS,
-        value: ZERO_BIGNUMBER,
+        sendValue: ZERO_BIGNUMBER,
+        depositValue: ZERO_BIGNUMBER,
         gasLimit: NON_ZERO_GASLIMIT,
         isCreation: true,
         data: NON_ZERO_DATA,
@@ -110,6 +117,7 @@ describe('DepositFeed', () => {
         depositFeed.address,
         depositFeed.interface.encodeFunctionData('depositTransaction', [
           ZERO_ADDRESS,
+          ZERO_BIGNUMBER,
           NON_ZERO_GASLIMIT,
           true,
           NON_ZERO_DATA,
@@ -121,17 +129,20 @@ describe('DepositFeed', () => {
       expect(eventArgs).to.deep.equal({
         from: applyL1ToL2Alias(dummy.address),
         to: ZERO_ADDRESS,
-        value: ZERO_BIGNUMBER,
+        sendValue: ZERO_BIGNUMBER,
+        depositValue: ZERO_BIGNUMBER,
         gasLimit: NON_ZERO_GASLIMIT,
         isCreation: true,
         data: NON_ZERO_DATA,
       })
     })
+
     describe('and increase its eth balance...', async () => {
       it('when an EOA deposits a transaction with an ETH value.', async () => {
         const balBefore = await ethers.provider.getBalance(depositFeed.address)
         await depositFeed.depositTransaction(
           NON_ZERO_ADDRESS,
+          ZERO_BIGNUMBER,
           NON_ZERO_GASLIMIT,
           false,
           '0x',
@@ -147,7 +158,8 @@ describe('DepositFeed', () => {
         expect(eventArgs).to.deep.equal({
           from: signerAddress,
           to: NON_ZERO_ADDRESS,
-          value: NON_ZERO_VALUE,
+          sendValue: ZERO_BIGNUMBER,
+          depositValue: NON_ZERO_VALUE,
           gasLimit: NON_ZERO_GASLIMIT,
           isCreation: false,
           data: '0x',
@@ -158,6 +170,7 @@ describe('DepositFeed', () => {
         const balBefore = await ethers.provider.getBalance(depositFeed.address)
         await depositFeed.depositTransaction(
           ZERO_ADDRESS,
+          ZERO_BIGNUMBER,
           NON_ZERO_GASLIMIT,
           true,
           '0x',
@@ -173,7 +186,8 @@ describe('DepositFeed', () => {
         expect(eventArgs).to.deep.equal({
           from: signerAddress,
           to: ZERO_ADDRESS,
-          value: NON_ZERO_VALUE,
+          sendValue: ZERO_BIGNUMBER,
+          depositValue: NON_ZERO_VALUE,
           gasLimit: NON_ZERO_GASLIMIT,
           isCreation: true,
           data: '0x',
@@ -190,6 +204,7 @@ describe('DepositFeed', () => {
           depositFeed.address,
           depositFeed.interface.encodeFunctionData('depositTransaction', [
             ZERO_ADDRESS,
+            ZERO_BIGNUMBER,
             NON_ZERO_GASLIMIT,
             true,
             NON_ZERO_DATA,
@@ -206,7 +221,8 @@ describe('DepositFeed', () => {
         expect(eventArgs).to.deep.equal({
           from: applyL1ToL2Alias(dummy.address),
           to: ZERO_ADDRESS,
-          value: NON_ZERO_VALUE,
+          sendValue: ZERO_BIGNUMBER,
+          depositValue: NON_ZERO_VALUE,
           gasLimit: NON_ZERO_GASLIMIT,
           isCreation: true,
           data: NON_ZERO_DATA,

--- a/packages/contracts/test/L1/DepositFeed.spec.ts
+++ b/packages/contracts/test/L1/DepositFeed.spec.ts
@@ -17,8 +17,8 @@ const decodeDepositEvent = async (
 ): Promise<{
   from: string
   to: string
-  depositValue: BigNumber
-  sendValue: BigNumber
+  mint: BigNumber
+  value: BigNumber
   gasLimit: BigNumber
   isCreation: boolean
   data: string
@@ -31,8 +31,8 @@ const decodeDepositEvent = async (
   return {
     from: eventArgs.from,
     to: eventArgs.to,
-    depositValue: eventArgs.depositValue,
-    sendValue: eventArgs.sendValue,
+    mint: eventArgs.mint,
+    value: eventArgs.value,
     gasLimit: eventArgs.gasLimit,
     isCreation: eventArgs.isCreation,
     data: eventArgs.data,
@@ -78,8 +78,8 @@ describe('DepositFeed', () => {
       expect(eventArgs).to.deep.equal({
         from: signerAddress,
         to: ZERO_ADDRESS,
-        depositValue: ZERO_BIGNUMBER,
-        sendValue: ZERO_BIGNUMBER,
+        mint: ZERO_BIGNUMBER,
+        value: ZERO_BIGNUMBER,
         gasLimit: NON_ZERO_GASLIMIT,
         isCreation: false,
         data: NON_ZERO_DATA,
@@ -100,8 +100,8 @@ describe('DepositFeed', () => {
       expect(eventArgs).to.deep.equal({
         from: signerAddress,
         to: ZERO_ADDRESS,
-        sendValue: ZERO_BIGNUMBER,
-        depositValue: ZERO_BIGNUMBER,
+        value: ZERO_BIGNUMBER,
+        mint: ZERO_BIGNUMBER,
         gasLimit: NON_ZERO_GASLIMIT,
         isCreation: true,
         data: NON_ZERO_DATA,
@@ -129,8 +129,8 @@ describe('DepositFeed', () => {
       expect(eventArgs).to.deep.equal({
         from: applyL1ToL2Alias(dummy.address),
         to: ZERO_ADDRESS,
-        sendValue: ZERO_BIGNUMBER,
-        depositValue: ZERO_BIGNUMBER,
+        value: ZERO_BIGNUMBER,
+        mint: ZERO_BIGNUMBER,
         gasLimit: NON_ZERO_GASLIMIT,
         isCreation: true,
         data: NON_ZERO_DATA,
@@ -158,8 +158,8 @@ describe('DepositFeed', () => {
         expect(eventArgs).to.deep.equal({
           from: signerAddress,
           to: NON_ZERO_ADDRESS,
-          sendValue: ZERO_BIGNUMBER,
-          depositValue: NON_ZERO_VALUE,
+          value: ZERO_BIGNUMBER,
+          mint: NON_ZERO_VALUE,
           gasLimit: NON_ZERO_GASLIMIT,
           isCreation: false,
           data: '0x',
@@ -186,8 +186,8 @@ describe('DepositFeed', () => {
         expect(eventArgs).to.deep.equal({
           from: signerAddress,
           to: ZERO_ADDRESS,
-          sendValue: ZERO_BIGNUMBER,
-          depositValue: NON_ZERO_VALUE,
+          value: ZERO_BIGNUMBER,
+          mint: NON_ZERO_VALUE,
           gasLimit: NON_ZERO_GASLIMIT,
           isCreation: true,
           data: '0x',
@@ -221,8 +221,8 @@ describe('DepositFeed', () => {
         expect(eventArgs).to.deep.equal({
           from: applyL1ToL2Alias(dummy.address),
           to: ZERO_ADDRESS,
-          sendValue: ZERO_BIGNUMBER,
-          depositValue: NON_ZERO_VALUE,
+          value: ZERO_BIGNUMBER,
+          mint: NON_ZERO_VALUE,
           gasLimit: NON_ZERO_GASLIMIT,
           isCreation: true,
           data: NON_ZERO_DATA,

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -25,8 +25,8 @@ fields (rlp encoded in the order they appear here):
 
 - `address from`: The address of the sender account.
 - `address to`: The address of the recipient account.
-- `uint256 depositValue`: The ETH value to mint on L2.
-- `uint256 sendValue`: The ETH value to send to the recipient account.
+- `uint256 mint`: The ETH value to mint on L2.
+- `uint256 value`: The ETH value to send to the recipient account.
 - `bytes data`: The input data.
 - `uint256 gasLimit`: The gasLimit for the L2 transaction.
 
@@ -70,7 +70,7 @@ using the correct derivation algorithm, the resulting state transition would be 
 
 In order to execute a deposit transaction:
 
-First, the balance of the `from` account MUST be increased by the amount of `depositValue`.
+First, the balance of the `from` account MUST be increased by the amount of `mint`.
 
 Then, the execution environment for a deposit transaction is initialized based on the transaction's
 values, in exactly the same manner as it would be for an EIP-155 transaction.
@@ -107,8 +107,8 @@ This transaction MUST have the following values:
 [L1 Attributes depositor account][depositor-account])
 2. `to` is `0x4200000000000000000000000000000000000014` (the address of the L1 attributes predeploy
    contract).
-3. `depositValue` is `0`
-4. `sendValue` is `0`
+3. `mint` is `0`
+4. `value` is `0`
 5. `gasLimit` is set to the maximum available.
 6. `data` is an [ABI] encoded call to the [L1 attributes predeploy][predeploy] contract's `setL1BlockValues()`
    function with correct values associated with the corresponding L1 block.
@@ -171,8 +171,8 @@ contract][deposit-feed-contract] on L1.
 2. `to` may be either:
     1. any 20-byte address (including the zero-address)
     2. `null` in which case a contract is created.
-3. `depositValue` is set to the emitted value.
-4. `sendValue` is set to the emitted value.
+3. `mint` is set to the emitted value.
+4. `value` is set to the emitted value.
 5. `gaslimit` is unchanged from the emitted value.
 6. `data` is unchanged from the emitted value. Depending on the value of `to` it is handled as
    either calldata or initialization code depending on the value of `to`.

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -23,11 +23,12 @@ fields (rlp encoded in the order they appear here):
 
 [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 
-- `address from`
-- `address to`
-- `uint256 value`
-- `bytes data`
-- `uint256 gasLimit`
+- `address from`: The address of the sender account.
+- `address to`: The address of the recipient account.
+- `uint256 depositValue`: The ETH value to mint on L2.
+- `uint256 sendValue`: The ETH value to send to the recipient account.
+- `bytes data`: The input data.
+- `uint256 gasLimit`: The gasLimit for the L2 transaction.
 
 In contrast to [EIP-155] transactions, this transaction type does not include signature information,
 and makes the `from` address explicit.
@@ -69,7 +70,7 @@ using the correct derivation algorithm, the resulting state transition would be 
 
 In order to execute a deposit transaction:
 
-First, the balance of the `from` account MUST be increased by the amount of `value`.
+First, the balance of the `from` account MUST be increased by the amount of `depositValue`.
 
 Then, the execution environment for a deposit transaction is initialized based on the transaction's
 values, in exactly the same manner as it would be for an EIP-155 transaction.
@@ -82,7 +83,7 @@ follows:
   [aliased][address-aliasing] by the deposit feed contract).
 - `context.calldata` set to `data`
 - `context.gas` set to `gasLimit`
-- `context.value` set to `value`
+- `context.value` set to `sendValue`
 
 #### Nonce handling
 
@@ -106,10 +107,13 @@ This transaction MUST have the following values:
 [L1 Attributes depositor account][depositor-account])
 2. `to` is `0x4200000000000000000000000000000000000014` (the address of the L1 attributes predeploy
    contract).
-3. `value` is `0`
-4. `gasLimit` is set to the maximum available.
-5. `data` is an [ABI] encoded call to the [L1 attributes predeploy][predeploy] contract's `setL1BlockValues()`
+3. `depositValue` is `0`
+4. `sendValue` is `0`
+5. `gasLimit` is set to the maximum available.
+6. `data` is an [ABI] encoded call to the [L1 attributes predeploy][predeploy] contract's `setL1BlockValues()`
    function with correct values associated with the corresponding L1 block.
+
+   <!-- TODO: Define how this account pays gas on these transactions. -->
 
 ## Special Accounts on L2
 
@@ -167,9 +171,10 @@ contract][deposit-feed-contract] on L1.
 2. `to` may be either:
     1. any 20-byte address (including the zero-address)
     2. `null` in which case a contract is created.
-3. `value` is unchanged from the emitted value.
-4. `gaslimit` is unchanged from the emitted value.
-5. `data` is unchanged from the emitted value. Depending on the value of `to` it is handled as
+3. `depositValue` is set to the emitted value.
+4. `sendValue` is set to the emitted value.
+5. `gaslimit` is unchanged from the emitted value.
+6. `data` is unchanged from the emitted value. Depending on the value of `to` it is handled as
    either calldata or initialization code depending on the value of `to`.
 
 ### Deposit Feed Contract


### PR DESCRIPTION
Replaces the `value` argument of the `TransactionDeposited` event, and Deposit Transaction type with two arguments:

1. `depositValue` is the ETH amount sent to the contract, to be minted on L2.
2. `sendValue` is the ETH amount to be sent to the recipient (analogous to `value` in s a typical L1 transaction).