### PR TITLE
Add a build command to package.json

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "test": "hardhat test",
+    "build": "hardhat compile",
     "lint:ts:check": "eslint .",
     "lint:contracts:check": "yarn solhint -f table 'contracts/**/*.sol'",
     "lint:check": "yarn lint:contracts:check && yarn lint:ts:check",


### PR DESCRIPTION
**Description**
A very small change to add a missing yarn command, so that we can run `yarn build` in the specs dir.