### PR TITLE
Use custom solidity errors

### DIFF
--- a/packages/contracts/contracts/L1/DepositFeed.sol
+++ b/packages/contracts/contracts/L1/DepositFeed.sol
@@ -5,6 +5,11 @@ pragma solidity 0.8.10;
  * @title DepositFeed
  */
 contract DepositFeed {
+    /**
+     * Deposits which create a new contract must set the recipient to address(0).
+     */
+    error NonZeroCreationTarget();
+
     // Constant for address aliasing
     uint160 private constant OFFSET = uint160(0x1111000000000000000000000000000000001111);
 
@@ -38,7 +43,7 @@ contract DepositFeed {
         bytes memory _data
     ) external payable {
         if (_isCreation && _to != address(0)) {
-            revert("Contract creation deposits must not specify a recipient address.");
+            revert NonZeroCreationTarget();
         }
 
         address from = msg.sender;

--- a/packages/contracts/contracts/L2/L1Block.sol
+++ b/packages/contracts/contracts/L2/L1Block.sol
@@ -5,6 +5,11 @@ pragma solidity 0.8.10;
  * @title L1Block
  */
 contract L1Block {
+    /**
+     * Only the Depositor account may call setL1BlockValues().
+     */
+    error OnlyDepositor();
+
     address public constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
 
     uint256 public number;
@@ -18,10 +23,9 @@ contract L1Block {
         uint256 _basefee,
         bytes32 _hash
     ) external {
-        require(
-            msg.sender == DEPOSITOR_ACCOUNT,
-            "Only callable by L1 Attributes Depositor Account"
-        );
+        if (msg.sender != DEPOSITOR_ACCOUNT) {
+            revert OnlyDepositor();
+        }
 
         number = _number;
         timestamp = _timestamp;

--- a/packages/contracts/contracts/L2/L1Block.sol
+++ b/packages/contracts/contracts/L2/L1Block.sol
@@ -5,27 +5,27 @@ pragma solidity 0.8.10;
  * @title L1Block
  */
 contract L1Block {
-  address constant depositorAccount = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
+    address public constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
 
-  uint256 public number;
-  uint256 public timestamp;
-  uint256 public basefee;
-  bytes32 public hash;
+    uint256 public number;
+    uint256 public timestamp;
+    uint256 public basefee;
+    bytes32 public hash;
 
-  function setL1BlockValues(
-    uint256 _number,
-    uint256 _timestamp,
-    uint256 _basefee,
-    bytes32 _hash
-  ) external {
-    require(
-      msg.sender == depositorAccount,
-      "Only callable by L1 Attributes Depositor Account"
-    );
+    function setL1BlockValues(
+        uint256 _number,
+        uint256 _timestamp,
+        uint256 _basefee,
+        bytes32 _hash
+    ) external {
+        require(
+            msg.sender == DEPOSITOR_ACCOUNT,
+            "Only callable by L1 Attributes Depositor Account"
+        );
 
-    number = _number;
-    timestamp = _timestamp;
-    basefee = _basefee;
-    hash = _hash;
-  }
+        number = _number;
+        timestamp = _timestamp;
+        basefee = _basefee;
+        hash = _hash;
+    }
 }

--- a/packages/contracts/test/L1/DepositFeed.spec.ts
+++ b/packages/contracts/test/L1/DepositFeed.spec.ts
@@ -58,9 +58,7 @@ describe('DepositFeed', () => {
         true,
         '0x'
       )
-    ).to.be.revertedWith(
-      'Contract creation deposits must not specify a recipient address.'
-    )
+    ).to.be.revertedWith('NonZeroCreationTarget()')
   })
 
   describe('Should emit the correct log values...', async () => {

--- a/packages/contracts/test/L2/L1Block.spec.ts
+++ b/packages/contracts/test/L2/L1Block.spec.ts
@@ -24,7 +24,7 @@ describe('L1Block contract', () => {
   it('setL1BlockValues: Should revert if not called by L1 Attributes Depositor Account', async () => {
     await expect(
       l1Block.connect(signer).setL1BlockValues(1, 2, 3, NON_ZERO_HASH)
-    ).to.be.revertedWith('Only callable by L1 Attributes Depositor Account')
+    ).to.be.revertedWith('OnlyDepositor()')
   })
 
   describe('Should return the correct block values for:', async () => {

--- a/packages/contracts/test/L2/L1Block.spec.ts
+++ b/packages/contracts/test/L2/L1Block.spec.ts
@@ -23,7 +23,11 @@ describe('L1Block contract', () => {
   })
 
   it('setL1BlockValues: Should revert if not called by L1 Attributes Depositor Account', async () => {
-
+    await expect(
+      l1Block.connect(signer).setL1BlockValues(1, 2, 3, NON_ZERO_HASH)
+    ).to.be.revertedWith(
+      'Only callable by L1 Attributes Depositor Account'
+    )
   })
 
   describe('Should return the correct block values for:', async () => {

--- a/packages/contracts/test/L2/L1Block.spec.ts
+++ b/packages/contracts/test/L2/L1Block.spec.ts
@@ -19,28 +19,26 @@ describe('L1Block contract', () => {
     await l1Block.deployed()
 
     depositor = await ethers.getSigner(DEPOSITOR_ACCOUNT)
-
   })
 
   it('setL1BlockValues: Should revert if not called by L1 Attributes Depositor Account', async () => {
     await expect(
       l1Block.connect(signer).setL1BlockValues(1, 2, 3, NON_ZERO_HASH)
-    ).to.be.revertedWith(
-      'Only callable by L1 Attributes Depositor Account'
-    )
+    ).to.be.revertedWith('Only callable by L1 Attributes Depositor Account')
   })
 
   describe('Should return the correct block values for:', async () => {
     before(async () => {
       await ethers.provider.send('hardhat_impersonateAccount', [
-        DEPOSITOR_ACCOUNT
+        DEPOSITOR_ACCOUNT,
       ])
       await ethers.provider.send('hardhat_setBalance', [
-        DEPOSITOR_ACCOUNT, '0xFFFFFFFFFFFF'
+        DEPOSITOR_ACCOUNT,
+        '0xFFFFFFFFFFFF',
       ])
       await l1Block.connect(depositor).setL1BlockValues(1, 2, 3, NON_ZERO_HASH)
       await ethers.provider.send('hardhat_stopImpersonatingAccount', [
-        DEPOSITOR_ACCOUNT
+        DEPOSITOR_ACCOUNT,
       ])
       l1Block.connect(signer)
     })


### PR DESCRIPTION
**Description**

Uses solidity's new [custom errors](https://docs.soliditylang.org/en/latest/contracts.html#errors) instead of reason strings, this approach saves gas and IMO is cleaner.

This PR builds on #108, otherwise they would conflict.