### PR TITLE
specs: Add README with design goals

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -3,6 +3,13 @@
 This directory contains the plain english specs for Optimism, an minimal optimistic rollup protocol
 that maintains 1:1 compatibility with Ethereum.
 
+## Specification Contents
+
+- [Glossary](glossary.md)
+- [Deposits](deposits.md)
+- [Execution Engine](exec-engine.md)
+- [Rollup Node](rollup-node.md)
+
 ## Design Goals
 
 Our aim is to design a protocol specification that is:
@@ -20,12 +27,12 @@ Our aim is to design a protocol specification that is:
   (like Geth) that already runs Ethereum. An ideal optimistic rollup design should be representable
   as a *diff* against Ethereum client software.
 - **Developer Driven:** Our designs will be developer driven to ensure we are actually building
-  something that people want to use. We must constantly engage with the developers who will be using our
-  software to avoid creating a system no one wants to use.
+  something that people want to use. We must constantly engage with the developers who will be using
+  our software to avoid creating a system no one wants to use.
 - **Clear and Readable:** The specs we write are written to be read. So tight feedback loop with the
   systems team consuming the spec is also key!
-- **Secure:** This is self-evident. We cannot lose money and in a system where even a bit of downtime can
-  result in loss of funds this means everything we build must be incredibly secure.
+- **Secure:** This is self-evident. We cannot lose money and in a system where even a bit of
+  downtime can result in loss of funds this means everything we build must be incredibly secure.
 - **Decentralizable:** Everything we build must have a clear path towards decentralization. Today
   Optimism relies on OptimismPBC to function, but eventually it will be managed by a DAO and even in
   that decentralized future our system must thrive.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,31 @@
+# Optimism specs
+
+This directory contains the plain english specs for Optimism, an minimal optimistic rollup protocol
+that maintains 1:1 compatibility with Ethereum.
+
+## Design Goals
+
+Our aim is to design a protocol specification that is:
+
+- **Fast:** When users send transactions, they get reliable confirmations with low-latency.
+  For example when swapping on Uniswap you should see that your transaction succeed in less than 2
+  seconds.
+- **Scalable:** It should be possible to handle an enormous number of transactions per second which
+  will enable us to charge low fees. V1.0 will enable us to scale up to and even past the gas limit
+  on L1. Later iterations will scale much further.
+- **Modular:** Our designs will use modularity to reduce complexity and enable parallel
+  contributions. Coming up with good conceptual frameworks & composable atoms of software enables us
+  to build extremely complex software even when any one person cannot hold that much in their brain.
+- **Minimal:** Rollups should be minimal to best take advantage of the battle-tested infrastructure
+  (like Geth) that already runs Ethereum. An ideal optimistic rollup design should be representable
+  as a *diff* against Ethereum client software.
+- **Developer Driven:** Our designs will be developer driven to ensure we are actually building
+  something that people want to use. We must constantly engage with the developers who will be using our
+  software to avoid creating a system no one wants to use.
+- **Clear and Readable:** The specs we write are written to be read. So tight feedback loop with the
+  systems team consuming the spec is also key!
+- **Secure:** This is self-evident. We cannot lose money and in a system where even a bit of downtime can
+  result in loss of funds this means everything we build must be incredibly secure.
+- **Decentralizable:** Everything we build must have a clear path towards decentralization. Today
+  Optimism relies on OptimismPBC to function, but eventually it will be managed by a DAO and even in
+  that decentralized future our system must thrive.


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a minimal README file to the specs directory, outlining the design goals. 

It could be argued that this file should include more information, such as usage info for installing or linting, but that should be separate PR.


**Metadata**
- Fixes #82 
