### PR TITLE
Input deriv test cleanup

### DIFF
--- a/opnode/l2/input_derivation.go
+++ b/opnode/l2/input_derivation.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	DepositEventABI     = "TransactionDeposited(address,address,uint256,uint256,bool,bytes)"
+	DepositEventABI     = "TransactionDeposited(address,address,uint256,uint256,uint256,bool,bytes)"
 	DepositEventABIHash = crypto.Keccak256Hash([]byte(DepositEventABI))
 	DepositContractAddr = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
 	L1InfoFuncSignature = "setL1BlockValues(uint256 _number, uint256 _timestamp, uint256 _basefee, bytes32 _hash)"


### PR DESCRIPTION
A mostly testing-only PR + `DepositEventABI` update (bug found with e2e testing by @maurelian), final polish before moving on with `staging` PRs to `main`.

Changes:
- L1 info deposit testing happens in reader-tests already (we go back and forth to encoded form, and check if the roundtrip doesn't lose info. With Go 1.18 we can fuzz that roundtrip later)
- `DeriveUserDeposits` returns a list of types deposit transactions, instead of the the geth transaction wrapper.
- No need to mock a whole block anymore, we only use the block-height for user deposits.
- Re-instate user deposits testing, with non-deposit logs, and less code

