### PR TITLE
ref impl: input derivation and reading l1-info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-
 )
 
 replace github.com/ethereum/go-ethereum v1.10.13 => github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220107224313-7f6d88bc156a

--- a/opnode/l2/input_derivation.go
+++ b/opnode/l2/input_derivation.go
@@ -1,0 +1,209 @@
+package l2
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/holiman/uint256"
+)
+
+var (
+	DepositEventABI     = "TransactionDeposited(address,address,uint256,uint256,uint256,bool,bytes)"
+	DepositEventABIHash = crypto.Keccak256Hash([]byte(DepositEventABI))
+	DepositContractAddr = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
+	L1InfoFuncSignature = "setL1BlockValues(uint256 _number, uint256 _timestamp, uint256 _basefee, bytes32 _hash)"
+	L1InfoFuncBytes4    = crypto.Keccak256([]byte(L1InfoFuncSignature))[:4]
+	L1InfoPredeployAddr = common.HexToAddress("0x4242424242424242424242424242424242424242")
+)
+
+// UnmarshalLogEvent decodes an EVM log entry emitted by the deposit contract into typed deposit data.
+//
+// parse log data for:
+//     event TransactionDeposited(
+//    	 address indexed from,
+//    	 address indexed to,
+//       uint256 mint,
+//    	 uint256 value,
+//    	 uint256 gasLimit,
+//    	 bool isCreation,
+//    	 data data
+//     );
+//
+// Deposits additionally get:
+//  - blockNum matching the L1 block height
+//  - txIndex: matching the deposit index, not L1 transaction index, since there can be multiple deposits per L1 tx
+func UnmarshalLogEvent(blockNum uint64, txIndex uint64, ev *types.Log) (*types.DepositTx, error) {
+	if len(ev.Topics) != 3 {
+		return nil, fmt.Errorf("expected 3 event topics (event identity, indexed from, indexed to)")
+	}
+	if ev.Topics[0] != DepositEventABIHash {
+		return nil, fmt.Errorf("invalid deposit event selector: %s, expected %s", ev.Topics[0], DepositEventABIHash)
+	}
+	if len(ev.Data) < 7*32 {
+		return nil, fmt.Errorf("deposit event data too small (%d bytes): %x", len(ev.Data), ev.Data)
+	}
+
+	var dep types.DepositTx
+
+	dep.BlockHeight = blockNum
+	dep.TransactionIndex = txIndex
+
+	// indexed 0
+	dep.From = common.BytesToAddress(ev.Topics[1][12:])
+	// indexed 1
+	to := common.BytesToAddress(ev.Topics[2][12:])
+
+	// unindexed data
+	offset := uint64(0)
+	dep.Value = new(big.Int).SetBytes(ev.Data[offset : offset+32])
+	offset += 32
+
+	dep.Mint = new(big.Int).SetBytes(ev.Data[offset : offset+32])
+	// 0 mint is represented as nil to skip minting code
+	if dep.Mint.Cmp(new(big.Int)) == 0 {
+		dep.Mint = nil
+	}
+	offset += 32
+
+	gas := new(big.Int).SetBytes(ev.Data[offset : offset+32])
+	if !gas.IsUint64() {
+		return nil, fmt.Errorf("bad gas value: %x", ev.Data[offset:offset+32])
+	}
+	offset += 32
+	dep.Gas = gas.Uint64()
+	// isCreation: If the boolean byte is 1 then dep.To will stay nil,
+	// and it will create a contract using L2 account nonce to determine the created address.
+	if ev.Data[offset+31] == 0 {
+		dep.To = &to
+	}
+	offset += 32
+	var dataOffset uint256.Int
+	dataOffset.SetBytes(ev.Data[offset : offset+32])
+	offset += 32
+	if dataOffset.Eq(uint256.NewInt(128)) {
+		return nil, fmt.Errorf("incorrect data offset: %v", dataOffset[0])
+	}
+
+	var dataLen uint256.Int
+	dataLen.SetBytes(ev.Data[offset : offset+32])
+	offset += 32
+	if !dataLen.IsUint64() || dataLen.Uint64() != uint64(len(ev.Data))-offset {
+		return nil, fmt.Errorf("inconsistent data length: %s, expected %d", dataLen.String(), uint64(len(ev.Data))-offset)
+	}
+
+	// remaining bytes fill the data
+	dep.Data = ev.Data[offset:]
+
+	return &dep, nil
+}
+
+type L1Info interface {
+	NumberU64() uint64
+	Time() uint64
+	Hash() common.Hash
+	BaseFee() *big.Int
+}
+
+func DeriveL1InfoDeposit(block L1Info) *types.DepositTx {
+	data := make([]byte, 4+8+8+32+32)
+	offset := 0
+	copy(data[offset:4], L1InfoFuncBytes4)
+	offset += 4
+	binary.BigEndian.PutUint64(data[offset:offset+8], block.NumberU64())
+	offset += 8
+	binary.BigEndian.PutUint64(data[offset:offset+8], block.Time())
+	offset += 8
+	block.BaseFee().FillBytes(data[offset : offset+32])
+	offset += 32
+	copy(data[offset:offset+32], block.Hash().Bytes())
+
+	return &types.DepositTx{
+		BlockHeight:      block.NumberU64(),
+		TransactionIndex: 0, // always the first transaction
+		From:             DepositContractAddr,
+		To:               &L1InfoPredeployAddr,
+		Mint:             nil,
+		Value:            big.NewInt(0),
+		Gas:              99_999_999,
+		Data:             data,
+	}
+}
+
+type ReceiptHash interface {
+	ReceiptHash() common.Hash
+}
+
+// CheckReceipts sanity checks that the receipts are consistent with the block data.
+func CheckReceipts(block ReceiptHash, receipts []*types.Receipt) bool {
+	hasher := trie.NewStackTrie(nil)
+	computed := types.DeriveSha(types.Receipts(receipts), hasher)
+	return block.ReceiptHash() == computed
+}
+
+// DeriveL2Transactions transforms a L1 block and corresponding receipts into the transaction inputs for a full L2 block
+func DeriveUserDeposits(height uint64, receipts []*types.Receipt) ([]*types.DepositTx, error) {
+	var out []*types.DepositTx
+
+	for _, rec := range receipts {
+		if rec.Status != types.ReceiptStatusSuccessful {
+			continue
+		}
+		for _, log := range rec.Logs {
+			if log.Address == DepositContractAddr {
+				// offset transaction index by 1, the first is the l1-info tx
+				dep, err := UnmarshalLogEvent(height, uint64(len(out))+1, log)
+				if err != nil {
+					return nil, fmt.Errorf("malformatted L1 deposit log: %v", err)
+				}
+				out = append(out, dep)
+			}
+		}
+	}
+	return out, nil
+}
+
+type BlockInput interface {
+	ReceiptHash
+	L1Info
+	MixDigest() common.Hash
+}
+
+func DeriveBlockInputs(block BlockInput, receipts []*types.Receipt) (*PayloadAttributes, error) {
+	if !CheckReceipts(block, receipts) {
+		return nil, fmt.Errorf("receipts are not consistent with the block's receipts root: %s", block.ReceiptHash())
+	}
+
+	l1Tx := types.NewTx(DeriveL1InfoDeposit(block))
+	opaqueL1Tx, err := l1Tx.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode L1 info tx")
+	}
+
+	userDeposits, err := DeriveUserDeposits(block.NumberU64(), receipts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive user deposits: %v", err)
+	}
+
+	encodedTxs := make([]Data, 0, len(userDeposits)+1)
+	encodedTxs = append(encodedTxs, opaqueL1Tx)
+
+	for i, tx := range userDeposits {
+		opaqueTx, err := types.NewTx(tx).MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode user tx %d", i)
+		}
+		encodedTxs = append(encodedTxs, opaqueTx)
+	}
+
+	return &PayloadAttributes{
+		Timestamp:             Uint64Quantity(block.Time()),
+		Random:                Bytes32(block.MixDigest()),
+		SuggestedFeeRecipient: common.Address{}, // nobody gets tx fees for deposits
+		Transactions:          encodedTxs,
+	}, nil
+}

--- a/opnode/l2/input_derivation.go
+++ b/opnode/l2/input_derivation.go
@@ -44,7 +44,7 @@ func UnmarshalLogEvent(blockNum uint64, txIndex uint64, ev *types.Log) (*types.D
 	if ev.Topics[0] != DepositEventABIHash {
 		return nil, fmt.Errorf("invalid deposit event selector: %s, expected %s", ev.Topics[0], DepositEventABIHash)
 	}
-	if len(ev.Data) < 7*32 {
+	if len(ev.Data) < 6*32 {
 		return nil, fmt.Errorf("deposit event data too small (%d bytes): %x", len(ev.Data), ev.Data)
 	}
 

--- a/opnode/l2/input_derivation_test.go
+++ b/opnode/l2/input_derivation_test.go
@@ -87,6 +87,9 @@ func GenerateDepositLog(deposit *types.DepositTx) *types.Log {
 	offset += 32
 	binary.BigEndian.PutUint64(data[offset+24:offset+32], uint64(len(deposit.Data)))
 	data = append(data, deposit.Data...)
+	if len(data)%32 != 0 { // pad to multiple of 32
+		data = append(data, make([]byte, 32-(len(data)%32))...)
+	}
 
 	return GenerateLog(DepositContractAddr, topics, data)
 }

--- a/opnode/l2/input_derivation_test.go
+++ b/opnode/l2/input_derivation_test.go
@@ -1,0 +1,195 @@
+package l2
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func GenerateAddress(rng *rand.Rand) (out common.Address) {
+	rng.Read(out[:])
+	return
+}
+
+func RandETH(rng *rand.Rand, max int64) *big.Int {
+	x := big.NewInt(rng.Int63n(max))
+	x = new(big.Int).Mul(x, big.NewInt(1e18))
+	return x
+}
+
+// Returns a DepositEvent customized on the basis of the id parameter.
+func GenerateDeposit(blockNum uint64, txIndex uint64, rng *rand.Rand) *types.DepositTx {
+	dataLen := rng.Int63n(10_000)
+	data := make([]byte, dataLen)
+	rng.Read(data)
+
+	var to *common.Address
+	if rng.Intn(2) == 0 {
+		x := GenerateAddress(rng)
+		to = &x
+	}
+	var mint *big.Int
+	if rng.Intn(2) == 0 {
+		mint = RandETH(rng, 200)
+	}
+
+	dep := &types.DepositTx{
+		BlockHeight:      blockNum,
+		TransactionIndex: txIndex,
+		From:             GenerateAddress(rng),
+		To:               to,
+		Value:            RandETH(rng, 200),
+		Gas:              uint64(rng.Int63n(10 * 1e6)), // 10 M gas max
+		Data:             data,
+		Mint:             mint,
+	}
+	return dep
+}
+
+// Generates an EVM log entry that encodes a TransactionDeposited event from the deposit contract.
+// Calls GenerateDeposit with random number generator to generate the deposit.
+func GenerateDepositLog(deposit *types.DepositTx) *types.Log {
+
+	toBytes := common.Hash{}
+	if deposit.To != nil {
+		toBytes = deposit.To.Hash()
+	}
+	topics := []common.Hash{
+		DepositEventABIHash,
+		deposit.From.Hash(),
+		toBytes,
+	}
+
+	data := make([]byte, 6*32)
+	offset := 0
+	deposit.Value.FillBytes(data[offset : offset+32])
+	offset += 32
+
+	if deposit.Mint != nil {
+		deposit.Mint.FillBytes(data[offset : offset+32])
+	}
+	offset += 32
+
+	binary.BigEndian.PutUint64(data[offset+24:offset+32], deposit.Gas)
+	offset += 32
+	if deposit.To == nil { // isCreation
+		data[offset+31] = 1
+	}
+	offset += 32
+	binary.BigEndian.PutUint64(data[offset+24:offset+32], 5*32)
+	offset += 32
+	binary.BigEndian.PutUint64(data[offset+24:offset+32], uint64(len(deposit.Data)))
+	data = append(data, deposit.Data...)
+
+	return GenerateLog(DepositContractAddr, topics, data)
+}
+
+// Generates an EVM log entry with the given topics and data.
+func GenerateLog(addr common.Address, topics []common.Hash, data []byte) *types.Log {
+	return &types.Log{
+		Address: addr,
+		Topics:  topics,
+		Data:    data,
+		Removed: false,
+
+		// ignored (zeroed):
+		BlockNumber: 0,
+		TxHash:      common.Hash{},
+		TxIndex:     0,
+		BlockHash:   common.Hash{},
+		Index:       0,
+	}
+}
+
+func TestUnmarshalLogEvent(t *testing.T) {
+	for i := int64(0); i < 100; i++ {
+		t.Run(fmt.Sprintf("random_deposit_%d", i), func(t *testing.T) {
+			rng := rand.New(rand.NewSource(1234 + i))
+			blockNum := rng.Uint64()
+			txIndex := uint64(rng.Intn(10000))
+			depInput := GenerateDeposit(blockNum, txIndex, rng)
+			log := GenerateDepositLog(depInput)
+			depOutput, err := UnmarshalLogEvent(blockNum, txIndex, log)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, depInput, depOutput)
+		})
+	}
+}
+
+// DeriveL1InfoDeposit is tested in reading_test.go, combined with the inverse ParseL1InfoDepositTxData
+
+// receiptData defines what a test receipt looks like
+type receiptData struct {
+	// false = failed tx
+	goodReceipt bool
+	// false = not a deposit log
+	DepositLogs []bool
+}
+
+type DeriveUserDepositsTestCase struct {
+	name   string
+	height uint64
+	// generate len(receipts) receipts
+	receipts []receiptData
+}
+
+func TestDeriveUserDeposits(t *testing.T) {
+	testCases := []DeriveUserDepositsTestCase{
+		{"no deposits", 100, []receiptData{}},
+		{"other log", 100, []receiptData{{true, []bool{false}}}},
+		{"success deposit", 100, []receiptData{{true, []bool{true}}}},
+		{"failed deposit", 100, []receiptData{{false, []bool{true}}}},
+		{"mixed deposits", 100, []receiptData{{true, []bool{true}}, {false, []bool{true}}}},
+		{"success multiple logs", 100, []receiptData{{true, []bool{true, true}}}},
+		{"failed multiple logs", 100, []receiptData{{false, []bool{true, true}}}},
+		{"not all deposit logs", 100, []receiptData{{true, []bool{true, false, true}}}},
+		{"random", 100, []receiptData{{true, []bool{false, false, true}}, {false, []bool{}}, {true, []bool{true}}}},
+	}
+	for i, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(1234 + int64(i)))
+			var receipts []*types.Receipt
+			var expectedDeposits []*types.DepositTx
+			for _, rData := range testCase.receipts {
+				var logs []*types.Log
+				status := types.ReceiptStatusSuccessful
+				if !rData.goodReceipt {
+					status = types.ReceiptStatusFailed
+				}
+				for _, isDeposit := range rData.DepositLogs {
+					if isDeposit {
+						dep := GenerateDeposit(testCase.height, uint64(1+len(expectedDeposits)), rng)
+						if status == types.ReceiptStatusSuccessful {
+							expectedDeposits = append(expectedDeposits, dep)
+						}
+						logs = append(logs, GenerateDepositLog(dep))
+					} else {
+						logs = append(logs, GenerateLog(GenerateAddress(rng), nil, nil))
+					}
+				}
+
+				receipts = append(receipts, &types.Receipt{
+					Type:   types.DynamicFeeTxType,
+					Status: status,
+					Logs:   logs,
+				})
+			}
+			got, err := DeriveUserDeposits(testCase.height, receipts)
+			assert.NoError(t, err)
+			assert.Equal(t, len(got), len(expectedDeposits))
+			for d, depTx := range got {
+				expected := expectedDeposits[d]
+				assert.Equal(t, expected, depTx)
+			}
+		})
+	}
+}

--- a/opnode/l2/reading.go
+++ b/opnode/l2/reading.go
@@ -1,0 +1,69 @@
+package l2
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// ParseL1InfoDepositTxData is the inverse of DeriveL1InfoDeposit, to see where the L2 chain is derived from
+func ParseL1InfoDepositTxData(data []byte) (nr uint64, time uint64, baseFee *big.Int, blockHash common.Hash, err error) {
+	if len(data) != 4+8+8+32+32 {
+		err = fmt.Errorf("data is unexpected length: %d", len(data))
+		return
+	}
+	offset := 4
+	nr = binary.BigEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	time = binary.BigEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	baseFee = new(big.Int).SetBytes(data[offset : offset+32])
+	offset += 32
+	blockHash.SetBytes(data[offset : offset+32])
+	return
+}
+
+type Block interface {
+	Hash() common.Hash
+	NumberU64() uint64
+	ParentHash() common.Hash
+	Transactions() types.Transactions
+}
+
+type Genesis struct {
+	L1 eth.BlockID
+	L2 eth.BlockID
+}
+
+// ParseBlockReferences takes a L2 block and determines which L1 block it was derived from, and the L2 self and parent id.
+func ParseBlockReferences(refL2Block Block, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error) {
+	refL2 = eth.BlockID{Hash: refL2Block.Hash(), Number: refL2Block.NumberU64()}
+	if refL2.Number <= genesis.L2.Number {
+		if refL2.Hash != genesis.L2.Hash {
+			err = fmt.Errorf("unexpected L2 genesis block: %s, expected %s", refL2, genesis.L2)
+			return
+		}
+		refL1 = genesis.L1
+		refL2 = genesis.L2
+		parentL2 = common.Hash{}
+		return
+	}
+
+	parentL2 = refL2Block.ParentHash()
+	txs := refL2Block.Transactions()
+	if len(txs) == 0 || txs[0].Type() != types.DepositTxType {
+		err = fmt.Errorf("l2 block is missing L1 info deposit tx, block hash: %s", refL2Block.Hash())
+		return
+	}
+	refL1Nr, _, _, refL1Hash, err := ParseL1InfoDepositTxData(txs[0].Data())
+	if err != nil {
+		err = fmt.Errorf("failed to parse L1 info deposit tx from L2 block: %v", err)
+		return
+	}
+	refL1 = eth.BlockID{Hash: refL1Hash, Number: refL1Nr}
+	return
+}

--- a/opnode/l2/reading_test.go
+++ b/opnode/l2/reading_test.go
@@ -1,0 +1,108 @@
+package l2
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+type l1MockInfo struct {
+	num     uint64
+	time    uint64
+	hash    common.Hash
+	baseFee *big.Int
+}
+
+func (l *l1MockInfo) NumberU64() uint64 {
+	return l.num
+}
+
+func (l *l1MockInfo) Time() uint64 {
+	return l.time
+}
+
+func (l *l1MockInfo) Hash() common.Hash {
+	return l.hash
+}
+
+func (l *l1MockInfo) BaseFee() *big.Int {
+	return l.baseFee
+}
+
+func randomHash(rng *rand.Rand) (out common.Hash) {
+	rng.Read(out[:])
+	return
+}
+
+func randomL1Info(rng *rand.Rand) *l1MockInfo {
+	return &l1MockInfo{
+		num:     rng.Uint64(),
+		time:    rng.Uint64(),
+		hash:    randomHash(rng),
+		baseFee: big.NewInt(rng.Int63n(1000_0000 * 1e9)), // a million GWEI
+	}
+}
+
+func makeInfo(fn func(l *l1MockInfo)) func(rng *rand.Rand) *l1MockInfo {
+	return func(rng *rand.Rand) *l1MockInfo {
+		l := randomL1Info(rng)
+		if fn != nil {
+			fn(l)
+		}
+		return l
+	}
+}
+
+var _ L1Info = (*l1MockInfo)(nil)
+
+type infoTest struct {
+	name   string
+	mkInfo func(rng *rand.Rand) *l1MockInfo
+}
+
+func TestParseL1InfoDepositTxData(t *testing.T) {
+	// Go 1.18 will have native fuzzing for us to use, until then, we cover just the below cases
+	cases := []infoTest{
+		{"random", makeInfo(nil)},
+		{"zero basefee", makeInfo(func(l *l1MockInfo) {
+			l.baseFee = new(big.Int)
+		})},
+		{"zero time", makeInfo(func(l *l1MockInfo) {
+			l.time = 0
+		})},
+		{"zero num", makeInfo(func(l *l1MockInfo) {
+			l.num = 0
+		})},
+		{"all zero", func(rng *rand.Rand) *l1MockInfo {
+			return &l1MockInfo{baseFee: new(big.Int)}
+		}},
+	}
+	for i, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			info := testCase.mkInfo(rand.New(rand.NewSource(int64(1234 + i))))
+			depTx := DeriveL1InfoDeposit(info)
+			nr, time, baseFee, h, err := ParseL1InfoDepositTxData(depTx.Data)
+			assert.NoError(t, err, "expected valid deposit info")
+			assert.Equal(t, nr, info.num)
+			assert.Equal(t, time, info.time)
+			assert.True(t, baseFee.Sign() >= 0)
+			assert.Equal(t, baseFee.Bytes(), info.baseFee.Bytes())
+			assert.Equal(t, h, info.hash)
+		})
+	}
+	t.Run("no data", func(t *testing.T) {
+		_, _, _, _, err := ParseL1InfoDepositTxData(nil)
+		assert.Error(t, err)
+	})
+	t.Run("not enough data", func(t *testing.T) {
+		_, _, _, _, err := ParseL1InfoDepositTxData([]byte{1, 2, 3, 4})
+		assert.Error(t, err)
+	})
+	t.Run("too much data", func(t *testing.T) {
+		_, _, _, _, err := ParseL1InfoDepositTxData(make([]byte, 4+8+8+32+32+1))
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Part of #119: staging -> main migration

This:
- Defines receipts to user deposits conversion
- Defines L1-info to deposit conversion
- Defines how to combine these deposits into payload attributes
- Test user-deposits
- Test l1-info deposits
- *(not tested, except in e2e): concatenating above deposits into payload attributes*
- Defines the inverse process of L1-info deposit: part of sync requires us to read which L1 info was last processed on L2, we simply parse the last L1-info transaction.


**Depends on #127**

Review: any team. No wild changes required, but naming is inconsistent, and we can try cross-referencing the functions. And should the inverse process (reading L1 info deposits) be specified as well, or is it implicitly defined already?

This took more dev iteration on staging, deriving inputs before using the engine-api for the outputs part can have many different typing approaches. This ended up working best for testing (minimize type transformations, simplify typing, interfaces / bare info instead of full blocks etc.).

Note: this also includes #123 (we can cherry-pick commits from review, or close that older PR)

