### PR TITLE
ref impl: derive outputs and run driver step

### DIFF
--- a/opnode/l2/driver_step.go
+++ b/opnode/l2/driver_step.go
@@ -1,0 +1,106 @@
+package l2
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type DriverAPI interface {
+	EngineAPI
+	EthBackend
+}
+
+func Execute(ctx context.Context, rpc DriverAPI, payload *ExecutionPayload) error {
+	execCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+	execRes, err := rpc.ExecutePayload(execCtx, payload)
+	if err != nil {
+		return fmt.Errorf("failed to execute payload: %v", err)
+	}
+	switch execRes.Status {
+	case ExecutionValid:
+		return nil
+	case ExecutionSyncing:
+		return fmt.Errorf("failed to execute payload %s, node is syncing, latest valid hash is %s", payload.ID(), execRes.LatestValidHash)
+	case ExecutionInvalid:
+		return fmt.Errorf("execution payload %s was INVALID! Latest valid hash is %s, ignoring bad block: %q", payload.ID(), execRes.LatestValidHash, execRes.ValidationError)
+	default:
+		return fmt.Errorf("unknown execution status on %s: %q, ", payload.ID(), string(execRes.Status))
+	}
+}
+
+func ForkchoiceUpdate(ctx context.Context, rpc DriverAPI, l2BlockHash common.Hash, l2Finalized common.Hash) error {
+	postState := &ForkchoiceState{
+		HeadBlockHash:      l2BlockHash, // no difference yet between Head and Safe, no data ahead of L1 yet.
+		SafeBlockHash:      l2BlockHash,
+		FinalizedBlockHash: l2Finalized,
+	}
+
+	fcCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+	fcRes, err := rpc.ForkchoiceUpdated(fcCtx, postState, nil)
+	if err != nil {
+		return fmt.Errorf("failed to update forkchoice: %v", err)
+	}
+	switch fcRes.Status {
+	case UpdateSyncing:
+		return fmt.Errorf("updated forkchoice, but node is syncing: %v", err)
+	case UpdateSuccess:
+		return nil
+	default:
+		return fmt.Errorf("unknown forkchoice status on %s: %q, ", l2BlockHash, string(fcRes.Status))
+	}
+}
+
+type Downloader interface {
+	Fetch(ctx context.Context, id eth.BlockID) (*types.Block, []*types.Receipt, error)
+}
+
+func DriverStep(ctx context.Context, log log.Logger, rpc DriverAPI,
+	dl Downloader, l1Input eth.BlockID, l2Parent eth.BlockID, l2Finalized common.Hash) (out eth.BlockID, err error) {
+
+	logger := log.New("input_l1", l1Input, "input_l2_parent", l2Parent, "finalized_l2", l2Finalized)
+
+	fetchCtx, cancel := context.WithTimeout(ctx, time.Second*20)
+	defer cancel()
+	bl, receipts, err := dl.Fetch(fetchCtx, l1Input)
+	if err != nil {
+		return eth.BlockID{}, fmt.Errorf("failed to fetch block with receipts: %v", err)
+	}
+	logger.Debug("fetched L1 data for driver")
+
+	attrs, err := DeriveBlockInputs(bl, receipts)
+	if err != nil {
+		return eth.BlockID{}, fmt.Errorf("failed to derive execution payload inputs: %v", err)
+	}
+	logger.Debug("derived L2 block inputs")
+
+	payload, err := DeriveBlockOutputs(ctx, rpc, l2Parent.Hash, l2Finalized, attrs)
+	if err != nil {
+		return eth.BlockID{}, fmt.Errorf("failed to derive execution payload: %v", err)
+	}
+
+	logger = logger.New("derived_l2", payload.ID())
+	logger.Info("derived full block")
+
+	err = Execute(ctx, rpc, payload)
+	if err != nil {
+		return eth.BlockID{}, fmt.Errorf("failed to apply execution payload: %v", err)
+	}
+	logger.Info("executed block")
+
+	err = ForkchoiceUpdate(ctx, rpc, payload.BlockHash, l2Finalized)
+	if err != nil {
+		return eth.BlockID{}, fmt.Errorf("failed to persist execution payload: %v", err)
+	}
+	logger.Info("updated fork-choice with block")
+
+	return payload.ID(), nil
+}

--- a/opnode/l2/output_derivation.go
+++ b/opnode/l2/output_derivation.go
@@ -1,0 +1,35 @@
+package l2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type BlockPreparer interface {
+	GetPayload(ctx context.Context, payloadId PayloadID) (*ExecutionPayload, error)
+	ForkchoiceUpdated(ctx context.Context, state *ForkchoiceState, attr *PayloadAttributes) (ForkchoiceUpdatedResult, error)
+}
+
+// DeriveBlockOutputs uses the engine API to derive a full L2 block from the block inputs.
+// The fcState does not affect the block production, but may inform the engine of finality and head changes to sync towards before block computation.
+func DeriveBlockOutputs(ctx context.Context, engine BlockPreparer, l2Parent common.Hash, l2Finalized common.Hash, attributes *PayloadAttributes) (*ExecutionPayload, error) {
+	fcState := &ForkchoiceState{
+		HeadBlockHash:      l2Parent, // no difference yet between Head and Safe, no data ahead of L1 yet.
+		SafeBlockHash:      l2Parent,
+		FinalizedBlockHash: l2Finalized,
+	}
+	fcResult, err := engine.ForkchoiceUpdated(ctx, fcState, attributes)
+	if err != nil {
+		return nil, fmt.Errorf("engine failed to process forkchoice update for block derivation: %v", err)
+	} else if fcResult.Status != UpdateSuccess {
+		return nil, fmt.Errorf("engine not in sync, failed to derive block, status: %s", fcResult.Status)
+	}
+
+	payload, err := engine.GetPayload(ctx, *fcResult.PayloadID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get payload: %v", err)
+	}
+	return payload, nil
+}


### PR DESCRIPTION
Part of #119: staging -> main migration

This:
- Implements the retrieval of output full execution-payload when given the payload-attributes (inputs)
- Implements how a L2 chain extends with a block: L1 data is retrieved, the input-derivation is called, the output-derivation is called, the payload is executed, and the forkchoice is updated 


**Depends on #128**

Review: any team.

Regarding testing: this code mostly strings together consecutive API calls, but there is little branching (aside from API error handling). Any suggestions how to best test this? End-to-end for API is verified to work, but no neat unit-test yet.

