### PR TITLE
ref impl: find starting point of sync, given L1 and L2 interfaces

### DIFF
--- a/opnode/l2/sync_reference.go
+++ b/opnode/l2/sync_reference.go
@@ -3,11 +3,9 @@ package l2
 import (
 	"context"
 	"fmt"
-	"math/big"
-	"time"
-
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
 	"github.com/ethereum/go-ethereum/common"
+	"math/big"
 )
 
 // SyncSource implements SyncReference with a L2 block sources and L1 hash-by-number source
@@ -21,8 +19,6 @@ func (src SyncSource) RefByL1Num(ctx context.Context, l1Num uint64) (self eth.Bl
 }
 
 func (src SyncSource) RefByL2Num(ctx context.Context, l2Num *big.Int, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
-	defer cancel()
 	refL2Block, err2 := src.L2.BlockByNumber(ctx, l2Num) // nil for latest block
 	if err2 != nil {
 		err = fmt.Errorf("failed to retrieve head L2 block: %v", err2)
@@ -32,8 +28,6 @@ func (src SyncSource) RefByL2Num(ctx context.Context, l2Num *big.Int, genesis *G
 }
 
 func (src SyncSource) RefByL2Hash(ctx context.Context, l2Hash common.Hash, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
-	defer cancel()
 	refL2Block, err2 := src.L2.BlockByHash(ctx, l2Hash)
 	if err2 != nil {
 		err = fmt.Errorf("failed to retrieve head L2 block: %v", err2)

--- a/opnode/l2/sync_reference.go
+++ b/opnode/l2/sync_reference.go
@@ -3,9 +3,10 @@ package l2
 import (
 	"context"
 	"fmt"
+	"math/big"
+
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
 	"github.com/ethereum/go-ethereum/common"
-	"math/big"
 )
 
 // SyncSource implements SyncReference with a L2 block sources and L1 hash-by-number source

--- a/opnode/l2/sync_reference.go
+++ b/opnode/l2/sync_reference.go
@@ -1,0 +1,56 @@
+package l2
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// SyncSource implements SyncReference with a L2 block sources and L1 hash-by-number source
+type SyncSource struct {
+	L1 eth.BlockLinkByNumber
+	L2 eth.BlockSource
+}
+
+func (src SyncSource) RefByL1Num(ctx context.Context, l1Num uint64) (self eth.BlockID, parent eth.BlockID, err error) {
+	return src.L1.BlockLinkByNumber(ctx, l1Num)
+}
+
+func (src SyncSource) RefByL2Num(ctx context.Context, l2Num *big.Int, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+	refL2Block, err2 := src.L2.BlockByNumber(ctx, l2Num) // nil for latest block
+	if err2 != nil {
+		err = fmt.Errorf("failed to retrieve head L2 block: %v", err2)
+		return
+	}
+	return ParseBlockReferences(refL2Block, genesis)
+}
+
+func (src SyncSource) RefByL2Hash(ctx context.Context, l2Hash common.Hash, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+	refL2Block, err2 := src.L2.BlockByHash(ctx, l2Hash)
+	if err2 != nil {
+		err = fmt.Errorf("failed to retrieve head L2 block: %v", err2)
+		return
+	}
+	return ParseBlockReferences(refL2Block, genesis)
+}
+
+// SyncReference helps inform the sync algorithm of the L2 sync-state and L1 canonical chain
+type SyncReference interface {
+	// RefByL1Num fetches the canonical L1 block hash and the parent for the given L1 block height.
+	RefByL1Num(ctx context.Context, l1Num uint64) (self eth.BlockID, parent eth.BlockID, err error)
+
+	// RefByL2Num fetches the L1 and L2 block IDs from the engine for the given L2 block height.
+	// Use a nil height to fetch the head.
+	RefByL2Num(ctx context.Context, l2Num *big.Int, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error)
+
+	// RefByL2Hash fetches the L1 and L2 block IDs from the engine for the given L2 block hash.
+	RefByL2Hash(ctx context.Context, l2Hash common.Hash, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error)
+}

--- a/opnode/l2/sync_reference.go
+++ b/opnode/l2/sync_reference.go
@@ -14,23 +14,27 @@ type SyncSource struct {
 	L2 eth.BlockSource
 }
 
+// RefByL1Num fetches the canonical L1 block hash and the parent for the given L1 block height.
 func (src SyncSource) RefByL1Num(ctx context.Context, l1Num uint64) (self eth.BlockID, parent eth.BlockID, err error) {
 	return src.L1.BlockLinkByNumber(ctx, l1Num)
 }
 
+// RefByL2Num fetches the L1 and L2 block IDs from the engine for the given L2 block height.
+// Use a nil height to fetch the head.
 func (src SyncSource) RefByL2Num(ctx context.Context, l2Num *big.Int, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error) {
 	refL2Block, err2 := src.L2.BlockByNumber(ctx, l2Num) // nil for latest block
 	if err2 != nil {
-		err = fmt.Errorf("failed to retrieve head L2 block: %v", err2)
+		err = fmt.Errorf("failed to retrieve L2 block: %v", err2)
 		return
 	}
 	return ParseBlockReferences(refL2Block, genesis)
 }
 
+// RefByL2Hash fetches the L1 and L2 block IDs from the engine for the given L2 block hash.
 func (src SyncSource) RefByL2Hash(ctx context.Context, l2Hash common.Hash, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error) {
 	refL2Block, err2 := src.L2.BlockByHash(ctx, l2Hash)
 	if err2 != nil {
-		err = fmt.Errorf("failed to retrieve head L2 block: %v", err2)
+		err = fmt.Errorf("failed to retrieve L2 block: %v", err2)
 		return
 	}
 	return ParseBlockReferences(refL2Block, genesis)

--- a/opnode/l2/sync_start.go
+++ b/opnode/l2/sync_start.go
@@ -59,7 +59,7 @@ func FindSyncStart(ctx context.Context, reference SyncReference, genesis *Genesi
 	// Search back: linear walk back from engine head. Should only be as deep as the reorg.
 	for refL2.Number > 0 {
 		// remember the canonical L1 block that builds on top of the L1 source block of the L2 parent block.
-		nextRefL1 = refL1
+		nextRefL1 = currentL1
 		refL1, refL2, parentL2, err = reference.RefByL2Hash(ctx, parentL2, genesis)
 		if err != nil {
 			// TODO: re-attempt look-up, now that we already traversed previous history?

--- a/opnode/l2/sync_start.go
+++ b/opnode/l2/sync_start.go
@@ -104,6 +104,7 @@ func FindSyncStart(ctx context.Context, reference SyncReference, genesis *Genesi
 	}
 	if currentL1 != genesis.L1 {
 		err = fmt.Errorf("unexpected L1 anchor block: %s, expected %s, %w", currentL1, genesis.L1, WrongChainErr)
+		return
 	}
 	// we got the correct genesis, all good, but a lot to sync!
 	return

--- a/opnode/l2/sync_start.go
+++ b/opnode/l2/sync_start.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
-
 	"github.com/ethereum/go-ethereum"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
@@ -15,9 +13,6 @@ import (
 var WrongChainErr = errors.New("wrong chain")
 
 func FindSyncStart(ctx context.Context, reference SyncReference, genesis *Genesis) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error) {
-	// 10 seconds for the whole thing (TODO: or do we want individual timeouts?)
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel()
 	var refL1 eth.BlockID
 	var parentL2 common.Hash
 	// Start at L2 head

--- a/opnode/l2/sync_start.go
+++ b/opnode/l2/sync_start.go
@@ -1,0 +1,89 @@
+package l2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func FindSyncStart(ctx context.Context, reference SyncReference, genesis *Genesis) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error) {
+	// 10 seconds for the whole thing (TODO: or do we want individual timeouts?)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+	var refL1 eth.BlockID
+	var parentL2 common.Hash
+	// Start at L2 head
+	refL1, refL2, parentL2, err = reference.RefByL2Num(ctx, nil, genesis)
+	if err != nil {
+		err = fmt.Errorf("failed to fetch L2 head: %v", err)
+		return
+	}
+	// Check if L1 source has the block
+	var currentL1 eth.BlockID
+	currentL1, _, err = reference.RefByL1Num(ctx, refL1.Number)
+	if err != nil {
+		err = fmt.Errorf("failed to lookup block %d in L1: %v", refL1.Number, err)
+		return
+	}
+	if currentL1 == refL1 {
+		// L1 node has head-block of execution-engine, so we should fetch the L1 block that builds on top.
+		var ontoL1 eth.BlockID
+		nextRefL1, ontoL1, err = reference.RefByL1Num(ctx, refL1.Number+1)
+		if err != nil {
+			// If refL1 is the head block, then we might not have a next block to build on the head
+			if errors.Is(err, ethereum.NotFound) {
+				// return the same as the engine head was already built on, no error.
+				nextRefL1 = refL1
+				refL2 = eth.BlockID{Hash: parentL2, Number: refL2.Number}
+				if refL2.Number > 0 {
+					refL2.Number -= 1
+				}
+				err = nil
+				return
+			}
+			return
+		}
+		// The L1 source might rug us with a reorg between API calls, catch that.
+		if ontoL1 != currentL1 {
+			err = fmt.Errorf("the L1 source reorged, the block for N+1 %s doesn't have the previously fetched block N %s as parent, but builds on %s instead", nextRefL1, currentL1, ontoL1)
+		}
+		return
+	}
+
+	// Search back: linear walk back from engine head. Should only be as deep as the reorg.
+	for refL2.Number > 0 {
+		// remember the canonical L1 block that builds on top of the L1 source block of the L2 parent block.
+		nextRefL1 = refL1
+		refL1, refL2, parentL2, err = reference.RefByL2Hash(ctx, parentL2, genesis)
+		if err != nil {
+			// TODO: re-attempt look-up, now that we already traversed previous history?
+			err = fmt.Errorf("failed to lookup block %s in L2: %v", refL2, err) // refL2 is previous parentL2
+			return
+		}
+		// Check if L1 source has the block that derived the L2 block we are planning to build on
+		currentL1, _, err = reference.RefByL1Num(ctx, refL1.Number)
+		if err != nil {
+			err = fmt.Errorf("failed to lookup block %d in L1: %v", refL1.Number, err)
+			return
+		}
+		if currentL1 == refL1 {
+			return
+		}
+		// TODO: after e.g. initial N steps, use binary search instead
+		// (relies on block numbers, not great for tip of chain, but nice-to-have in deep reorgs)
+	}
+	// Enforce that we build on the desired genesis block.
+	// The engine might be configured for a different chain or older testnet.
+	if refL2 != genesis.L2 {
+		err = fmt.Errorf("engine was anchored at unexpected block: %s, expected %s", refL2, genesis.L2)
+		return
+	}
+	// we got the correct genesis, all good, but a lot to sync!
+	return
+}

--- a/opnode/l2/sync_start.go
+++ b/opnode/l2/sync_start.go
@@ -15,8 +15,7 @@ var WrongChainErr = errors.New("wrong chain")
 
 // FindSyncStart finds nextRefL1: the L1 block needed next for sync, to derive into a L2 block on top of refL2.
 // If the L1 reorgs then this will find the common history to build on top of and then follow the first step of the reorg.
-func FindSyncStart(ctx context.Context, reference SyncReference, genesis *Genesis) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error) {
-	var refL1 eth.BlockID    // the L1 block that was derived into refL2
+func FindSyncStart(ctx context.Context, reference SyncReference, genesis *Genesis) (refL1, nextRefL1, refL2 eth.BlockID, err error) {
 	var parentL2 common.Hash // the parent of refL2
 	// Start at L2 head
 	refL1, refL2, parentL2, err = reference.RefByL2Num(ctx, nil, genesis)

--- a/opnode/l2/sync_start.go
+++ b/opnode/l2/sync_start.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"

--- a/opnode/l2/sync_start_test.go
+++ b/opnode/l2/sync_start_test.go
@@ -139,7 +139,7 @@ func (c *syncStartTestCase) Run(t *testing.T) {
 	}
 	expectedRefL2 := mockID(c.ExpectedRefL2, expectedRefL2Num)
 
-	nextRefL1, refL2, err := FindSyncStart(context.Background(), msr, genesis)
+	_, nextRefL1, refL2, err := FindSyncStart(context.Background(), msr, genesis)
 	if c.ExpectedErr != nil {
 		assert.Error(t, err, "got next L1 %s (%d), onto L2: %s (%d)", nextRefL1.Hash[:1], nextRefL1.Number, refL2.Hash[:1], refL2.Number)
 		assert.ErrorIs(t, err, c.ExpectedErr)

--- a/opnode/l2/sync_start_test.go
+++ b/opnode/l2/sync_start_test.go
@@ -1,0 +1,171 @@
+package l2
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+type l2Block struct {
+	Self   eth.BlockID
+	FromL1 eth.BlockID
+}
+
+type mockSyncReference struct {
+	L2 []l2Block
+	L1 []eth.BlockID
+}
+
+func (m *mockSyncReference) RefByL1Num(ctx context.Context, l1Num uint64) (self eth.BlockID, parent eth.BlockID, err error) {
+	self = m.L1[l1Num]
+	if l1Num > 0 {
+		parent = m.L1[l1Num-1]
+	}
+	return
+}
+
+func (m *mockSyncReference) RefByL2Num(ctx context.Context, l2Num *big.Int, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error) {
+	if len(m.L2) == 0 {
+		panic("bad test, no l2 chain")
+	}
+	i := uint64(len(m.L2) - 1)
+	if l2Num != nil {
+		i = l2Num.Uint64()
+	}
+	head := m.L2[i]
+	refL1 = head.FromL1
+	refL2 = head.Self
+	if i > 0 {
+		parentL2 = m.L2[i-1].Self.Hash
+	}
+	return
+}
+
+func (m *mockSyncReference) RefByL2Hash(ctx context.Context, l2Hash common.Hash, genesis *Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error) {
+	for i, bl := range m.L2 {
+		if bl.Self.Hash == l2Hash {
+			return m.RefByL2Num(ctx, big.NewInt(int64(i)), genesis)
+		}
+	}
+	err = ethereum.NotFound
+	return
+}
+
+var _ SyncReference = (*mockSyncReference)(nil)
+
+func mockID(id rune, num uint64) eth.BlockID {
+	var h common.Hash
+	copy(h[:], string(id))
+	return eth.BlockID{Hash: h, Number: uint64(num)}
+}
+
+func chainL1(ids string) (out []eth.BlockID) {
+	for i, id := range ids {
+		out = append(out, mockID(id, uint64(i)))
+	}
+	return
+}
+
+func chainL2(l1 []eth.BlockID, ids string) (out []l2Block) {
+	for i, id := range ids {
+		out = append(out, l2Block{
+			Self:   mockID(id, uint64(i)),
+			FromL1: l1[i],
+		})
+	}
+	return
+}
+
+type syncStartTestCase struct {
+	Name string
+
+	OffsetL2 uint64
+	EngineL1 string
+	EngineL2 string
+	ActualL1 string
+
+	GenesisL2 rune
+
+	ExpectedNextRefL1 rune
+	ExpectedRefL2     rune
+
+	ExpectedErr error
+}
+
+func (c *syncStartTestCase) Run(t *testing.T) {
+	engL1 := chainL1(c.EngineL1)
+	engL2 := chainL2(engL1[c.OffsetL2:], c.EngineL2)
+	actL1 := chainL1(c.ActualL1)
+
+	msr := &mockSyncReference{
+		L2: engL2,
+		L1: actL1,
+	}
+
+	genesis := &Genesis{
+		L1: actL1[0],
+		L2: mockID(c.GenesisL2, 0),
+	}
+
+	expectedNextRefL1Num := ^uint64(0)
+	for i, id := range c.ActualL1 {
+		if id == c.ExpectedNextRefL1 {
+			expectedNextRefL1Num = uint64(i)
+		}
+	}
+	expectedNextRefL1 := mockID(c.ExpectedNextRefL1, expectedNextRefL1Num)
+
+	expectedNextRefL2Num := ^uint64(0)
+	for i, id := range c.EngineL2 {
+		if id == c.ExpectedRefL2 {
+			expectedNextRefL2Num = uint64(i)
+		}
+	}
+	expectedRefL2 := mockID(c.ExpectedRefL2, expectedNextRefL2Num)
+
+	nextRefL1, refL2, err := FindSyncStart(context.Background(), msr, genesis)
+	if c.ExpectedErr != nil {
+		assert.Equal(t, c.ExpectedErr, err)
+	} else {
+		assert.NoError(t, err)
+		assert.Equal(t, expectedNextRefL1, nextRefL1, "expected %s (nr %d) but got %s (nr %d)", expectedNextRefL1.Hash[:1], expectedNextRefL1.Number, nextRefL1.Hash[:1], nextRefL1.Number)
+		assert.Equal(t, expectedRefL2, refL2, "expected %s (nr %d) but got %s (nr %d)", expectedRefL2.Hash[:1], expectedRefL2.Number, refL2.Hash[:1], refL2.Number)
+	}
+}
+
+func TestFindSyncStart(t *testing.T) {
+	testCases := []syncStartTestCase{
+		{
+			Name:              "happy extend",
+			OffsetL2:          0,
+			EngineL1:          "ab",
+			EngineL2:          "AB",
+			ActualL1:          "abc",
+			GenesisL2:         'A',
+			ExpectedNextRefL1: 'c',
+			ExpectedRefL2:     'B',
+			ExpectedErr:       nil,
+		},
+		{
+			Name:              "reorg two steps back",
+			OffsetL2:          0,
+			EngineL1:          "abc",
+			EngineL2:          "ABC",
+			ActualL1:          "axy",
+			GenesisL2:         'A',
+			ExpectedNextRefL1: 'x',
+			ExpectedRefL2:     'A',
+			ExpectedErr:       nil,
+		},
+		// TODO more test cases
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, testCase.Run)
+	}
+}

--- a/opnode/l2/sync_start_test.go
+++ b/opnode/l2/sync_start_test.go
@@ -94,6 +94,7 @@ type syncStartTestCase struct {
 	ActualL1 string
 
 	GenesisL2 rune
+	GenesisL1 rune
 
 	ExpectedNextRefL1 rune
 	ExpectedRefL2     rune
@@ -112,7 +113,7 @@ func (c *syncStartTestCase) Run(t *testing.T) {
 	}
 
 	genesis := &Genesis{
-		L1: actL1[0],
+		L1: mockID(c.GenesisL1, c.OffsetL2),
 		L2: mockID(c.GenesisL2, 0),
 	}
 
@@ -157,6 +158,7 @@ func TestFindSyncStart(t *testing.T) {
 			EngineL1:          "ab",
 			EngineL2:          "AB",
 			ActualL1:          "abc",
+			GenesisL1:         'a',
 			GenesisL2:         'A',
 			ExpectedNextRefL1: 'c',
 			ExpectedRefL2:     'B',
@@ -168,6 +170,7 @@ func TestFindSyncStart(t *testing.T) {
 			EngineL1:          "ab",
 			EngineL2:          "AB",
 			ActualL1:          "abcdef",
+			GenesisL1:         'a',
 			GenesisL2:         'A',
 			ExpectedNextRefL1: 'c',
 			ExpectedRefL2:     'B',
@@ -179,6 +182,7 @@ func TestFindSyncStart(t *testing.T) {
 			EngineL1:          "abcde",
 			EngineL2:          "ABCDE",
 			ActualL1:          "abcde",
+			GenesisL1:         'a',
 			GenesisL2:         'A',
 			ExpectedNextRefL1: 'e',
 			ExpectedRefL2:     'D',
@@ -190,6 +194,7 @@ func TestFindSyncStart(t *testing.T) {
 			EngineL1:          "a",
 			EngineL2:          "A",
 			ActualL1:          "a",
+			GenesisL1:         'a',
 			GenesisL2:         'A',
 			ExpectedNextRefL1: 'a',
 			ExpectedRefL2:     0, // actual zero hash before genesis hash
@@ -201,6 +206,7 @@ func TestFindSyncStart(t *testing.T) {
 			EngineL1:          "abc",
 			EngineL2:          "ABC",
 			ActualL1:          "axy",
+			GenesisL1:         'a',
 			GenesisL2:         'A',
 			ExpectedNextRefL1: 'x',
 			ExpectedRefL2:     'A',
@@ -212,6 +218,7 @@ func TestFindSyncStart(t *testing.T) {
 			EngineL1:          "abcd",
 			EngineL2:          "ABCD",
 			ActualL1:          "abcx",
+			GenesisL1:         'a',
 			GenesisL2:         'A',
 			ExpectedNextRefL1: 'x',
 			ExpectedRefL2:     'C',
@@ -223,6 +230,7 @@ func TestFindSyncStart(t *testing.T) {
 			EngineL1:          "abcdef",
 			EngineL2:          "ABCDEF",
 			ActualL1:          "abc",
+			GenesisL1:         'a',
 			GenesisL2:         'A',
 			ExpectedNextRefL1: 0,
 			ExpectedRefL2:     0,
@@ -234,6 +242,7 @@ func TestFindSyncStart(t *testing.T) {
 			EngineL1:          "abcdef",
 			EngineL2:          "ABCDEF",
 			ActualL1:          "abcx",
+			GenesisL1:         'a',
 			GenesisL2:         'A',
 			ExpectedNextRefL1: 'x',
 			ExpectedRefL2:     'C',
@@ -245,6 +254,7 @@ func TestFindSyncStart(t *testing.T) {
 			EngineL1:          "abcdef",
 			EngineL2:          "ABCDEF",
 			ActualL1:          "xyz",
+			GenesisL1:         'a',
 			GenesisL2:         'A',
 			ExpectedNextRefL1: 0,
 			ExpectedRefL2:     0,
@@ -256,6 +266,7 @@ func TestFindSyncStart(t *testing.T) {
 			EngineL1:          "abcdef",
 			EngineL2:          "ABCDEF",
 			ActualL1:          "xyz",
+			GenesisL1:         'a',
 			GenesisL2:         'X',
 			ExpectedNextRefL1: 0,
 			ExpectedRefL2:     0,

--- a/specs/exec-engine.md
+++ b/specs/exec-engine.md
@@ -119,12 +119,12 @@ as the engine implementation can sync state faster through methods like [snap-sy
 
 ### Happy-path sync
 
-1. Engine API informs engine of chain head, unconditionally (part of regular node operation):
+1. The rollup node informs the engine of the L2 chain head, unconditionally (part of regular node operation):
    - [`engine_executePayloadV1`][engine_executePayloadV1] is called with latest L2 block derived from L1.
    - [`engine_forkchoiceUpdatedV1`][engine_forkchoiceUpdatedV1] is called with the current
      `unsafe`/`safe`/`finalized` L2 block hashes.
-2. Engine requests headers from peers, in reverse till the parent hash matches the local chain
-3. Engine catches up:
+2. The engine requests headers from peers, in reverse till the parent hash matches the local chain
+3. The engine catches up:
     a) A form of state sync is activated towards the finalized or head block hash
     b) A form of block sync pulls block bodies and processes towards head block hash
 
@@ -134,17 +134,12 @@ the operation within the engine is the exact same as with L1 (although with an E
 ### Worst-case sync
 
 1. Engine is out of sync, not peered and/or stalled due other reasons.
-2. rollup node periodically fetches latest head from engine (`eth_getBlockByNumber`)
-3. rollup node activates sync if the engine is out of sync but not syncing through P2P (`eth_syncing`)
-4. rollup node inserts blocks, derived from L1, one by one,
-   starting from the engine head (or genesis block if unrecognized) up to the latest chain head.
-   (`engine_forkchoiceUpdatedV1`, `engine_executePayloadV1`)
+2. The rollup node maintains latest head from engine (poll `eth_getBlockByNumber` and/or maintain a header subscription)
+3. The rollup node activates sync if the engine is out of sync but not syncing through P2P (`eth_syncing`)
+4. The rollup node inserts blocks, derived from L1, one by one, potentially adapting to L1 reorg(s),
+   as outlined in the [rollup node spec] (`engine_forkchoiceUpdatedV1`, `engine_executePayloadV1`)
 
-See [rollup node sync spec][rollup-node-sync] for L1-based block syncing specification.
-
-> **TODO**: rollup node block-by-block sync (covered in rollup node PR #43)
-
-[rollup-node-sync]: ./rollup-node.md#sync
+[rollup node spec]: rollup-node.md
 
 [eip-2718]: https://eips.ethereum.org/EIPS/eip-2718
 [eip-2718-transactions]: https://eips.ethereum.org/EIPS/eip-2718#transactions

--- a/specs/exec-engine.md
+++ b/specs/exec-engine.md
@@ -46,7 +46,9 @@ Within the rollup, the types of forkchoice updates translate as:
 - `finalizedBlockHash`: irreversible block hash, matches lower boundary of the dispute period.
 
 To support rollup functionality, one backwards-compatible change is introduced
-to [`engine_forkchoiceUpdatedV1`][engine_forkchoiceUpdatedV1]:
+to [`engine_forkchoiceUpdatedV1`][engine_forkchoiceUpdatedV1]: the extended `PayloadAttributesV1`
+
+#### Extended PayloadAttributesV1
 
 [`PayloadAttributesV1`][PayloadAttributesV1] is extended with a `transactions` field,
 equivalent to the `transactions` field in [`ExecutionPayloadV1`][ExecutionPayloadV1]:

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -58,6 +58,7 @@ First inputs are derived from L1 source data, then outputs are derived with L2 s
 The L2 block has the same format as a L1 block: a block-header and a list of transactions.
 
 The list of transaction carries:
+
 - A *[L1 attributes transaction]* (always first item)
 - L2 transactions deposited by users in the L1 block (*[deposits]*, if any)
 
@@ -86,7 +87,6 @@ These are then encoded as a [L1 attributes deposit] to update the [L1 Attributes
 [L1 attributes deposit]: deposits.md#l1-attributes-deposit
 [L1 Attributes Predeploy]: deposits.md#l1-attributes-predeploy
 
-
 #### Transaction deposits derivation
 
 A [transaction deposit][transaction deposits] is an L2 transaction that has been submitted on L1, via a call to the
@@ -114,7 +114,6 @@ The object properties must be set as follows:
 [unix time]: https://en.wikipedia.org/wiki/Unix_time
 [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
-
 
 ### Output derivation
 

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -10,10 +10,10 @@
 [block gossip]: glossary.md#block-gossip
 [rollup driver]: glossary.md#rollup-driver
 [deposits]: glossary.md#deposits
-[deposit-feed]: glossary.md#L2-deposit-feed-contract
+[deposit feed contract]: glossary.md#L2-deposit-feed-contract
 [L2 chain inception]: glossary.md#L2-chain-inception
 [receipts]: glossary.md#receipt
-[L1 attributes deposit]: glossary.md#l1-attributes-deposit
+[L1 attributes transaction]: glossary.md#l1-attributes-transaction
 [transaction deposits]: glossary.md#transaction-deposits
 
 The [rollup node] is the component responsible for [deriving the L2 chain][derivation] from L1 blocks (and their
@@ -41,188 +41,134 @@ concerned with the specification of the rollup driver.
 
 ## L2 Chain Derivation
 
-[l2-chain-derivation]: #l2-chain-derivation
+This section specifies how the [rollup driver] derives one L2 block per every L1 block.
 
-This section specifies how the [rollup driver] derives one L2 block per every L1 block. The L2 block will carry
-*[deposits]*, including a single *[L1 attributes deposit]* (which carries L1 block attributes) and zero or more
-*[transaction deposits]* submitted by user on L1.
+First inputs are derived from L1 source data, then outputs are derived with L2 state through the [Engine API].
 
-----
+[Engine API]: exec-engine.md#engine-api
 
-### From L1 blocks to payload attributes
+### Input derivation
 
-[payload-attr]: #From-L1-blocks-to-payload-attributes
-[`PayloadAttributesOPV1`]: #From-L1-blocks-to-payload-attributes
+The L2 block has the same format as a L1 block: a block-header and a list of transactions.
 
-The rollup reads the following data from each L1 block:
+The list of transaction carries:
+- A *[L1 attributes transaction]* (always first item)
+- L2 transactions deposited by users in the L1 block (*[deposits]*, if any)
 
-- L1 block attributes
-  - block number
-  - timestamp
-  - basefee
-  - *random* (the output of the [`RANDOM` opcode][random])
-- L1 log entries emitted for [transaction deposits]
+While deposits are notably (but not only) used to "deposit" (bridge) ETH and tokens to L2,
+the word *deposit* should be understood as "a transaction *deposited* to L2".
+
+The L1 attributes are read from the L1 block header, while other deposits are read from the block's [receipts].
+
+All derived deposits each get two additional attributes during derivation, to ensure uniqueness:
+
+- `blockHeight`: the block-height of the L1 input the deposit was derived from
+- `transactionIndex`: the transaction-index within the L2 transactions list
+
+#### L1 attributes transaction derivation
+
+The rollup reads the following attributes from each L1 block to derive a [L1 attributes transaction]:
+
+- block number
+- timestamp
+- basefee
+- *random* (the output of the [`RANDOM` opcode][random])
+
+These are then encoded as a [L1 attributes deposit] to update the [L1 Attributes Predeploy].
 
 [random]: https://eips.ethereum.org/EIPS/eip-4399
+[L1 attributes deposit]: deposits.md#l1-attributes-deposit
+[L1 Attributes Predeploy]: deposits.md#l1-attributes-predeploy
+
+
+#### Transaction deposits derivation
 
 A [transaction deposit][transaction deposits] is an L2 transaction that has been submitted on L1, via a call to the
-[deposit feed contract][deposit-feed].
+[deposit feed contract].
 
-While deposits are notably (but not only) used to "deposit" (bridge) ETH and tokens to L2, the word *deposit* should be
-understood as "a transaction *deposited* to L2".
-
-The L1 attributes are read from the L1 block header, while deposits are read from the block's [receipts]. Refer to the
-[**deposit feed contract specification**][deposit-feed-spec] for details on how deposits are encoded as log entries.
+Refer to the[**deposit feed contract specification**][deposit-feed-spec] for details on how
+deposit properties are emitted in deposit log entries.
 
 [deposit-feed-spec]: deposits.md#deposit-feed-contract
 
-From the data read from L1, the rollup node constructs an expanded version of the [Engine API PayloadAttributesV1
-object][PayloadAttributesV1], which includes an additional `transactions` field:
+#### Payload attributes derivation
 
-[PayloadAttributesV1]: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#payloadattributesv1
-
-```js
-PayloadAttributesOPV1: {
-    timestamp: QUANTITY
-    random: DATA (32 bytes)
-    suggestedFeeRecipient: DATA (20 bytes)
-    transactions: array of DATA
-}
-```
-
-The type notation used here refers to the [HEX value encoding] used by the [Ethereum JSON-RPC API
-specification][JSON-RPC-API], as this structure will need to be sent over JSON-RPC. `array` refers to a JSON array.
-
-[HEX value encoding]: https://eth.wiki/json-rpc/API#hex-value-encoding
-[JSON-RPC-API]: https://github.com/ethereum/execution-apis
+From the data read from L1, the rollup node constructs an [expanded version of PayloadAttributesV1],
+which includes an additional `transactions` field.
 
 The object properties must be set as follows:
 
-- `timestamp` is set to the current [unix time] (number of elapsed seconds since 00:00:00 UTC on 1 January 1970),
+- `timestamp` is set to the current [unix time],
   rounded to the closest multiple of 2 seconds. No two blocks may have the same timestamp.
 - `random` is set to the *random* L1 block attribute
-- `suggestedFeeRecipient` is set to an address where the sequencer would like to direct the fees
-- `transactions` is an array containing the [L1 attributes deposit] as well as [transaction deposits], whose format is
-  specified in the [next section][payload-format].
+- `suggestedFeeRecipient` is set to the zero-address for deposit-blocks, since there is no sequencer.
+- `transactions` is an array of the derived deposits, all encoded in the [EIP-2718] format.
 
+[expanded version of PayloadAttributesV1]: exec-engine.md#extended-payloadattributesv1
 [unix time]: https://en.wikipedia.org/wiki/Unix_time
-[yellow paper]: https://github.com/ethereum/yellowpaper
-[EIP-155]: https://eips.ethereum.org/EIPS/eip-155
-[EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
 [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
 
-----
 
-### Payload Transaction Format
+### Output derivation
 
-[payload-format]: #payload-transaction-format
+Building a full block requires the earlier [derived payload attributes](#payload-attributes-derivation)
+(`payloadAttributes` argument) as well as the previous L2 state (`forkchoiceState` argument), defined by
+the [`engine_forkchoiceUpdatedV1`] method of the [Engine API]:
 
-The `transactions` array is filled with user-submitted deposits, prefixed by the (single) [L1 attributes deposit]. The
-format for deposits is described at [the top of the deposit specification][deposit-transaction-type].
+- `headBlockHash`: block hash of the last block of the L2 chain, according to the rollup driver.
+- `safeBlockHash`: same as `headBlockHash`.
+- `finalizedBlockHash`: the hash of the block whose number is `number(headBlockHash) - FINALIZATION_DELAY_BLOCKS` if
+  the number of that block is `>= L2_CHAIN_INCEPTION`, 0 otherwise (where `FINALIZATION_DELAY_BLOCKS == 50400`
+  (approximately 7 days worth of L1 blocks) and `L2_CHAIN_INCEPTION` is the [L2 chain inception] (the number of the
+  first L1 block for which an L2 block was produced). See the [Finalization Guarantees][finalization] section for more
+  details.
 
-[deposit-transaction-type]: deposits.md#the-deposit-transaction-type
+[`engine_forkchoiceUpdatedV1`]: exec-engine.md#engine_forkchoiceUpdatedV1
 
-The rollup node is responsible for encoding the L1 attributes deposit based on the attributes (block number, timestamp
-and basefee) of the L1 block, as specified in the [L1 Attributes Deposit][l1-attributes-deposit-spec] section of the
-deposit specification. It must also encode the transaction deposits based on the `TransactionDeposited` event
-emitted by the deposit contract, as specified by the [L1 Transaction Deposits][l1-transaction-deposits] section of the
-same document.
+Once this first API call completes, `engine_getPayloadV1` is used to fetch the full L2 block,
+as specified in the [Engine API].
 
-[l1-attributes-deposit-spec]: deposits.md#l1-attributes-deposit
-[l1-transaction-deposits]: deposits.md#l1-transaction-deposits
+[`engine_getPayloadV1`]: exec-engine.md#engine_executepayloadv1
+[`ExecutionPayloadV1`]: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#executionpayloadv1
 
-Here is an example valid `PayloadAttributesOPV1` object, which contains an L1 attributes deposit as well as a single
-transaction deposit:
+## Completing a driver step
 
-```js
-{
-  timestamp: "0x61a6336f",
-  random: "0xde5dff2b0982ecbbd38081eb8f4aed0525140dc1c1d56f995b4fa801a3f2649e",
-  suggestedFeeRecipient: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
-  transactions: [
-    "TODO generate abi-encoded L1 attribute deposit",
-    "0x02f87101058459682f0085199c82cc0082520894ab5801a7d398351b8be11c439e05c5b3259aec9b8609184e72a00080c080a0a6d217a91ea344fc09f740f104f764d71bb1ca9a8e159117d2d27091ea5fce91a04cf5add5f5b7d791a2c4663ab488cb581df800fe0910aa755099ba466b49fd69"
-  ]
-}
-```
+After deriving a full L2 block, two more API calls are required to persist the result:
+execute the new block, and update the forkchoice to reflect the new head.
 
-----
+### Execute
 
-### Building the L2 block with the execution engine
+Execute through the [`engine_executePayloadV1`] API method with the derived payload to update the engine state.
+A `"status": "VALID"` result is required to continue.
 
-[calling-exec-engine]: #building-the-L2-block-with-the-execution-engine
+[`engine_executePayloadV1`]: exec-engine.md#engine_executepayloadv1
 
-The Optimism [execution engine] is specified in the [Execution Engine Specification].
+### Forkchoice
 
-[Execution Engine Specification]: exec-engine.md
+Update the L2 head with a [`engine_forkchoiceUpdatedV1`] API call, now without `payloadAttributes` argument,
+and updated `forkchoiceState` argument:
 
-This section defines how the rollup driver must interact with the execution engine's in order to convert [payload
-attributes] into L2 blocks.
+- `headBlockHash`: block hash of the derived payload
+- `safeBlockHash`: same as `headBlockHash`
+- `finalizedBlockHash`: finalized-block. May have changed since last call.
+   Not strictly required to change, this can be adjusted later.
 
-> **TODO** This section probably includes too much redundant details that will
-> need to be removed once the execution engine spec is up.
+A `"status": "SUCCESS"` result then indicates if the engine successfully updated the head to the derived payload.
 
-Optimism's execution engine API is built upon [Ethereum's Engine API specification][eth-engine-api], with a
-couple of modifications. That specification builds upon [Ethereum's JSON-RPC API specification][JSON-RPC-API], which
-itself builds upon the [JSON-RPC specification][JSON-RPC].
+## API error handling
 
-[eth-engine-api]: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md
-[JSON-RPC]: https://www.jsonrpc.org/specification
-
-In particular, the [Ethereum's Engine API specification][eth-engine-api] specifies a [JSON-RPC] endpoint with a number
-of JSON-RPC routes, which are the means through which the rollup driver interacts with the execution engine.
-
-Instead of calling [`engine_forkchoiceUpdatedV1`], the rollup driver must call the new [`engine_forkchoiceUpdatedOPV1`]
-route. This has the same signature, except that:
-
-[`engine_forkchoiceUpdatedV1`]: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_forkchoiceupdatedv1
-[`engine_forkchoiceUpdatedOPV1`]: exec-engine.md#engine_forkchoiceupdatedv1
-
-- it takes a [`PayloadAttributesOPV1`] object as input instead of [`PayloadAttributesV1`][PayloadAttributesV1]. The
-  execution engine must include the valid transactions supplied in this object in the block, in the same order as they
-  were supplied, and only those. See the [previous section][payload-attr] for the specification of how the properties
-  must be set.
-
-- we repurpose the [`ForkchoiceStateV1`] structure with the following property semantics:
-  - `headBlockHash`: block hash of the last block of the L2 chain, according to the rollup driver.
-  - `safeBlockHash`: same as `headBlockHash`.
-  - `finalizedBlockHash`: the hash of the block whose number is `number(headBlockHash) - FINALIZATION_DELAY_BLOCKS` if
-    the number of that block is `>= L2_CHAIN_INCEPTION`, 0 otherwise (where `FINALIZATION_DELAY_BLOCKS` = 50400,
-    approximately 7 days worth of L1 blocks) and `L2_CHAIN_INCEPTION` is the [L2 chain inception] (the number of the
-    first L1 block for which an L2 block was produced). See the [Finalization Guarantees][finalization] section for more
-    details.
-
-[`ForkchoiceStateV1`]: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#ForkchoiceStateV1
-
-> **Note:** the properties of `ForkchoiceStateV1` can be used to anchor queries to the regular (non-engine-API) JSON-RPC
-> endpoint of the execution engine. [See here for more information.][L2-JSON-RPC-API]
-
-[L2-JSON-RPC-API]: exec-engine.md#engine-api
-
-> **TODO LINK** L2 JSON RPC API (might be the same as [L1's][JSON-RPC-API])
-
-The `payloadID` returned by [`engine_forkchoiceUpdatedOPV1`] can then be passed to [`engine_getPayloadV1`] in order to
-obtain an [`ExecutionPayloadV1`], which fully defines a new L2 block.
-
-The rollup driver must then instruct the execution engine to execute the block by calling [`engine_executePayloadV1`].
-This returns the new L2 block hash.
-
-All invocations of [`engine_forkchoiceUpdatedOPV1`], [`engine_getPayloadV1`] and [`engine_executePayloadV1`] by the
+All invocations of [`engine_forkchoiceUpdatedV1`], [`engine_getPayloadV1`] and [`engine_executePayloadV1`] by the
 rollup driver should not result in errors assuming conformity with the specification. Said otherwise, all errors are
 implementation concerns and it is up to them to handle them (e.g. by retrying, or by stopping the chain derivation and
 requiring manual user intervention).
 
 The following scenarios are assimilated to errors:
 
-- [`engine_forkchoiceUpdatedOPV1`] returning a `status` of `"SYNCING"` instead of `"SUCCESS"` whenever passed a
+- [`engine_forkchoiceUpdatedV1`] returning a `status` of `"SYNCING"` instead of `"SUCCESS"` whenever passed a
   `headBlockHash` that it retrieved from a previous call to [`engine_executePayloadV1`].
 - [`engine_executePayloadV1`] returning a `status` of `"SYNCING"` or `"INVALID"` whenever passed an execution payload
   that was obtained by a previous call to [`engine_getPayloadV1`].
-
-[`engine_getPayloadV1`]: exec-engine.md#engine_executepayloadv1
-[`ExecutionPayloadV1`]: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#executionpayloadv1
-[`engine_executePayloadV1`]: exec-engine.md#engine_executepayloadv1
 
 ## Handling L1 Re-Orgs
 
@@ -239,7 +185,7 @@ In practice, the L1 chain is processed incrementally. However, the L1 chain may 
 head of the L1 chain changes to a block that is not the child of the previous head but rather one of its "cousins" (i.e.
 the descendant of an ancestor of the previous head). In those case, the rollup driver must:
 
-1. Call [`engine_forkchoiceUpdatedOPV1`] for the new L2 chain head
+1. Call [`engine_forkchoiceUpdatedV1`] for the new L2 chain head
     - Pass `null` for the `payloadAttributes` parameter.
     - Fill the [`ForkchoiceStateV1`] object according to [the section on the execution engine][calling-exec-engine], but
       set `headBlockHash` to the hash of the new L2 chain head. `safeBlockHash` and `finalizedBlockHash` must be updated
@@ -248,13 +194,14 @@ the descendant of an ancestor of the previous head). In those case, the rollup d
 3. Otherwise the call returns `"SYNCING"`, and we must derive the new blocks ourselves. Start by locating the *common
    ancestor*, a block that is an ancestor of both the previous and new head.
 4. Isolate the range of L1 blocks from `common ancestor` (excluded) to `new head` (included).
-5. For each such block, call [`engine_forkchoiceUpdatedOPV1`], [`engine_getPayloadV1`], and [`engine_executePayloadV1`].
+5. For each such block, call [`engine_forkchoiceUpdatedV1`], [`engine_getPayloadV1`], and [`engine_executePayloadV1`].
    - Fill the [`PayloadAttributesOPV1`] object according to [the section on payload attributes][payload-attr].
    - Fill the [`ForkchoiceStateV1`] object according to [the section on the execution engine][calling-exec-engine], but
      set `headBlockHash` to the hash of the last processed L2 block (use the hash of the common ancestor initially)
      instead of the last L2 chain head. `safeBlockHash` and `finalizedBlockHash` must be updated accordingly.
 
 [block sync]: exec-engine.md#sync
+[merge]: https://ethereum.org/en/eth2/merge/
 
 > Note that post-[merge], the L1 chain will offer finalization guarantees meaning that it won't be able to re-org more
 > than `FINALIZATION_DELAY_BLOCKS == 50400` in the past, hence preserving our finalization guarantees.


### PR DESCRIPTION
Part of #119: staging -> main migration

This:
- Implements a "sync reference" interface, and implementation that implements it based on common RPC source interfaces. To mock chain status easily for sync starting-point testing.
- Implements algorithm from @karlfloersch (with missing edge cases handled) to find the starting point for sync, statelessly (i.e. no rollup-node storage requirement, nor in-memory chain/tree)


**Depends on #129**

Review: any team.

Spec (TODO): update reference how we find the starting point of sync.

Testing: ~~different starting point edge cases~~ done