### PR TITLE
ref impl: driver agent: respond to head events and stay in sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/tsdb v0.7.1 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tklauser/go-sysconf v0.3.5 // indirect
 	github.com/tklauser/numcpus v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,7 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/opnode/internal/testlog/LICENSE
+++ b/opnode/internal/testlog/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/opnode/internal/testlog/README.md
+++ b/opnode/internal/testlog/README.md
@@ -1,0 +1,6 @@
+# testlog
+
+`github.com/ethereum/go-ethereum/internal/testlog`: a Go-ethereum util for logging in tests.
+
+Since we use the same logging, but as an external package, we have to move the test utility to our own internal package.
+

--- a/opnode/internal/testlog/testlog.go
+++ b/opnode/internal/testlog/testlog.go
@@ -1,0 +1,142 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package testlog provides a log handler for unit tests.
+package testlog
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// Handler returns a log handler which logs to the unit test log of t.
+func Handler(t *testing.T, level log.Lvl) log.Handler {
+	return log.LvlFilterHandler(level, &handler{t, log.TerminalFormat(false)})
+}
+
+type handler struct {
+	t   *testing.T
+	fmt log.Format
+}
+
+func (h *handler) Log(r *log.Record) error {
+	h.t.Logf("%s", h.fmt.Format(r))
+	return nil
+}
+
+// logger implements log.Logger such that all output goes to the unit test log via
+// t.Logf(). All methods in between logger.Trace, logger.Debug, etc. are marked as test
+// helpers, so the file and line number in unit test output correspond to the call site
+// which emitted the log message.
+type logger struct {
+	t  *testing.T
+	l  log.Logger
+	mu *sync.Mutex
+	h  *bufHandler
+}
+
+type bufHandler struct {
+	buf []*log.Record
+	fmt log.Format
+}
+
+func (h *bufHandler) Log(r *log.Record) error {
+	h.buf = append(h.buf, r)
+	return nil
+}
+
+// Logger returns a logger which logs to the unit test log of t.
+func Logger(t *testing.T, level log.Lvl) log.Logger {
+	l := &logger{
+		t:  t,
+		l:  log.New(),
+		mu: new(sync.Mutex),
+		h:  &bufHandler{fmt: log.TerminalFormat(false)},
+	}
+	l.l.SetHandler(log.LvlFilterHandler(level, l.h))
+	return l
+}
+
+func (l *logger) Trace(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Trace(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) Debug(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Debug(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) Info(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Info(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) Warn(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Warn(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) Error(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Error(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) Crit(msg string, ctx ...interface{}) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.l.Crit(msg, ctx...)
+	l.flush()
+}
+
+func (l *logger) New(ctx ...interface{}) log.Logger {
+	return &logger{l.t, l.l.New(ctx...), l.mu, l.h}
+}
+
+func (l *logger) GetHandler() log.Handler {
+	return l.l.GetHandler()
+}
+
+func (l *logger) SetHandler(h log.Handler) {
+	l.l.SetHandler(h)
+}
+
+// flush writes all buffered messages and clears the buffer.
+func (l *logger) flush() {
+	l.t.Helper()
+	for _, r := range l.h.buf {
+		l.t.Logf("%s", l.h.fmt.Format(r))
+	}
+	l.h.buf = nil
+}

--- a/opnode/l2/driver.go
+++ b/opnode/l2/driver.go
@@ -177,7 +177,7 @@ func (e *EngineDriver) Drive(ctx context.Context, dl Downloader, l1Heads <-chan 
 					continue
 				}
 				e.Log.Debug("finding next sync step, engine syncing", "l2", e.l2Head, "l1", e.l1Head)
-				_, nextRefL1, refL2, err := FindSyncStart(ctx, e.SyncRef, &e.Genesis)
+				nextRefL1, refL2, err := FindSyncStart(ctx, e.SyncRef, &e.Genesis)
 				if err != nil {
 					e.Log.Error("Failed to find sync starting point", "err", err)
 					continue

--- a/opnode/l2/driver.go
+++ b/opnode/l2/driver.go
@@ -1,0 +1,207 @@
+package l2
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/event"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type EngineDriver struct {
+	Ctx context.Context
+	Log log.Logger
+	// API bindings to execution engine
+	RPC DriverAPI
+
+	SyncRef SyncReference
+
+	// The current driving force, to shutdown before closing the engine.
+	driveSub ethereum.Subscription
+	// There may only be 1 driver at a time
+	driveLock sync.Mutex
+
+	// Locks the L1 and L2 head changes, to keep a consistent view of the engine
+	headLock sync.RWMutex
+
+	// l1Head tracks the L1 block corresponding to the l2Head
+	l1Head eth.BlockID
+
+	// l2Head tracks the head-block of the engine
+	l2Head eth.BlockID
+
+	// l2Finalized tracks the block the engine can safely regard as irreversible
+	// (a week for disputes, or maybe shorter if we see L1 finalize and take the derived L2 chain up till there)
+	l2Finalized eth.BlockID
+
+	// The L1 block we are syncing towards, may be ahead of l1Head
+	l1Target eth.BlockID
+
+	// Genesis starting point
+	Genesis Genesis
+}
+
+// L1Head returns the block-id (hash and number) of the last L1 block that was derived into the L2 block
+func (e *EngineDriver) L1Head() eth.BlockID {
+	e.headLock.RLock()
+	defer e.headLock.RUnlock()
+	return e.l1Head
+}
+
+// L2Head returns the block-id (hash and number) of the L2 chain head
+func (e *EngineDriver) L2Head() eth.BlockID {
+	e.headLock.RLock()
+	defer e.headLock.RUnlock()
+	return e.l2Head
+}
+
+func (e *EngineDriver) Head() (l1Head eth.BlockID, l2Head eth.BlockID) {
+	e.headLock.RLock()
+	defer e.headLock.RUnlock()
+	return e.l1Head, e.l2Head
+}
+
+func (e *EngineDriver) UpdateHead(l1Head eth.BlockID, l2Head eth.BlockID) {
+	e.headLock.Lock()
+	defer e.headLock.Unlock()
+	e.l1Head = l1Head
+	e.l2Head = l2Head
+}
+
+func (e *EngineDriver) RequestHeadUpdate() error {
+	e.headLock.Lock()
+	defer e.headLock.Unlock()
+	refL1, refL2, _, err := e.SyncRef.RefByL2Num(e.Ctx, nil, &e.Genesis)
+	if err != nil {
+		return err
+	}
+	e.l1Head = refL1
+	e.l2Head = refL2
+	return nil
+}
+
+func (e *EngineDriver) Drive(dl Downloader, l1Heads <-chan eth.HeadSignal) ethereum.Subscription {
+	e.driveLock.Lock()
+	defer e.driveLock.Unlock()
+	if e.driveSub != nil {
+		return e.driveSub
+	}
+	e.driveSub = event.NewSubscription(func(quit <-chan struct{}) error {
+		// keep making many sync steps if we can make sync progress
+		hot := time.Millisecond * 30
+		// check on sync regularly, but prioritize sync triggers with head updates etc.
+		cold := time.Second * 8
+		// at least try every minute to sync, even if things are going well
+		max := time.Minute
+
+		syncTicker := time.NewTicker(cold)
+		defer syncTicker.Stop()
+
+		// backoff sync attempts if we are not making progress
+		backoff := cold
+		syncQuickly := func() {
+			syncTicker.Reset(hot)
+			backoff = cold
+		}
+		// exponential backoff, add 10% each step, up to max.
+		syncBackoff := func() {
+			backoff += backoff / 10
+			if backoff > max {
+				backoff = max
+			}
+			syncTicker.Reset(backoff)
+		}
+
+		l2HeadPollTicker := time.NewTicker(time.Second * 14)
+		defer l2HeadPollTicker.Stop()
+
+		onL2Update := func() {
+			// When we updated L2, we want to continue sync quickly
+			syncQuickly()
+			// And we want to slow down requesting the L2 engine for its head (we just changed it ourselves)
+			// Request head if we don't successfully change it in the next 14 seconds.
+			l2HeadPollTicker.Reset(time.Second * 14)
+		}
+
+		for {
+			select {
+			case <-e.Ctx.Done():
+				return e.Ctx.Err()
+			case <-quit:
+				return nil
+			case <-l2HeadPollTicker.C:
+				if err := e.RequestHeadUpdate(); err != nil {
+					e.Log.Error("failed to fetch L2 head info", "err", err)
+				}
+				continue
+			case l1HeadSig := <-l1Heads:
+				if e.l1Head == l1HeadSig.Self {
+					e.Log.Debug("Received L1 head signal, already synced to it, ignoring event", "l1_head", e.l1Head)
+					continue
+				}
+				if e.l1Head == l1HeadSig.Parent {
+					// Simple extend, a linear life is easy
+					if l2ID, err := DriverStep(e.Ctx, e.Log, e.RPC, dl, l1HeadSig.Self, e.l2Head, e.l2Finalized.Hash); err != nil {
+						e.Log.Error("Failed to extend L2 chain with new L1 block", "l1", l1HeadSig.Self, "l2", e.l2Head, "err", err)
+						// Retry sync later
+						e.l1Target = l1HeadSig.Self
+						onL2Update()
+						continue
+					} else {
+						e.UpdateHead(l1HeadSig.Self, l2ID)
+						continue
+					}
+				}
+				if e.l1Head.Number < l1HeadSig.Parent.Number {
+					e.Log.Debug("Received new L1 head, engine is out of sync, cannot immediately process", "l1", l1HeadSig.Self, "l2", e.l2Head)
+				} else {
+					e.Log.Warn("Received a L1 reorg, syncing new alternative chain", "l1", l1HeadSig.Self, "l2", e.l2Head)
+				}
+
+				e.l1Target = l1HeadSig.Self
+				syncQuickly()
+				continue
+			case <-syncTicker.C:
+				// If already synced, or in case of failure, we slow down
+				syncBackoff()
+				if e.l1Head == e.l1Target {
+					e.Log.Debug("Engine is fully synced", "l1_head", e.l1Head, "l2_head", e.l2Head)
+					// TODO: even though we are fully synced, it may be worth attempting anyway,
+					// in case the e.l1Head is not updating (failed/broken L1 head subscription)
+					continue
+				}
+				e.Log.Debug("finding next sync step, engine syncing", "l2", e.l2Head, "l1", e.l1Head)
+				refL1, refL2, err := FindSyncStart(e.Ctx, e.SyncRef, &e.Genesis)
+				if err != nil {
+					e.Log.Error("Failed to find sync starting point", "err", err)
+					continue
+				}
+				if refL1 == e.l1Head {
+					e.Log.Debug("Engine is already synced, aborting sync", "l1_head", e.l1Head, "l2_head", e.l2Head)
+					continue
+				}
+				if l2ID, err := DriverStep(e.Ctx, e.Log, e.RPC, dl, refL1, refL2, e.l2Finalized.Hash); err != nil {
+					e.Log.Error("Failed to sync L2 chain with new L1 block", "l1", refL1, "onto_l2", refL2, "err", err)
+					continue
+				} else {
+					e.UpdateHead(refL1, l2ID)
+				}
+				// Successfully stepped toward target. Continue quickly if we are not there yet
+				if e.l1Head != e.l1Target {
+					onL2Update()
+				}
+			}
+		}
+	})
+	return e.driveSub
+}
+
+func (e *EngineDriver) Close() {
+	e.RPC.Close()
+	e.driveSub.Unsubscribe()
+}

--- a/opnode/l2/driver.go
+++ b/opnode/l2/driver.go
@@ -177,20 +177,20 @@ func (e *EngineDriver) Drive(ctx context.Context, dl Downloader, l1Heads <-chan 
 					continue
 				}
 				e.Log.Debug("finding next sync step, engine syncing", "l2", e.l2Head, "l1", e.l1Head)
-				refL1, refL2, err := FindSyncStart(ctx, e.SyncRef, &e.Genesis)
+				_, nextRefL1, refL2, err := FindSyncStart(ctx, e.SyncRef, &e.Genesis)
 				if err != nil {
 					e.Log.Error("Failed to find sync starting point", "err", err)
 					continue
 				}
-				if refL1 == e.l1Head {
+				if nextRefL1 == e.l1Head {
 					e.Log.Debug("Engine is already synced, aborting sync", "l1_head", e.l1Head, "l2_head", e.l2Head)
 					continue
 				}
-				if l2ID, err := DriverStep(ctx, e.Log, e.RPC, dl, refL1, refL2, e.l2Finalized.Hash); err != nil {
-					e.Log.Error("Failed to sync L2 chain with new L1 block", "l1", refL1, "onto_l2", refL2, "err", err)
+				if l2ID, err := DriverStep(ctx, e.Log, e.RPC, dl, nextRefL1, refL2, e.l2Finalized.Hash); err != nil {
+					e.Log.Error("Failed to sync L2 chain with new L1 block", "l1", nextRefL1, "onto_l2", refL2, "err", err)
 					continue
 				} else {
-					e.UpdateHead(refL1, l2ID)
+					e.UpdateHead(nextRefL1, l2ID) // l2ID is derived from the nextRefL1
 				}
 				// Successfully stepped toward target. Continue quickly if we are not there yet
 				if e.l1Head != e.l1Target {

--- a/opnode/l2/driver.go
+++ b/opnode/l2/driver.go
@@ -12,9 +12,18 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// Driver exposes the driver functionality that maintains the external execution-engine.
 type Driver interface {
+	// requestEngineHead retrieves the L2 head reference of the engine, as well as the L1 reference it was derived from.
+	// An error is returned when the L2 head information could not be retrieved (timeout or connection issue)
 	requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL2 eth.BlockID, err error)
+	// findSyncStart statelessly finds the next L1 block to derive, and on which L2 block it applies.
+	// If the engine is fully synced, then the last derived L1 block, and parent L2 block, is repeated.
+	// An error is returned if the sync starting point could not be determined (due to timeouts, wrong-chain, etc.)
 	findSyncStart(ctx context.Context) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error)
+	// driverStep explicitly calls the engine to derive a L1 block into a L2 block, and apply it on top of the given L2 block.
+	// The finalized L2 block is provided to update the engine with finality, but does not affect the derivation step itself.
+	// The resulting L2 block ID is returned, or an error if the derivation fails.
 	driverStep(ctx context.Context, nextRefL1 eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error)
 }
 

--- a/opnode/l2/driver.go
+++ b/opnode/l2/driver.go
@@ -3,7 +3,6 @@ package l2
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/event"
@@ -13,11 +12,17 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+type Driver interface {
+	requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL2 eth.BlockID, err error)
+	findSyncStart(ctx context.Context) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error)
+	driverStep(ctx context.Context, nextRefL1 eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error)
+}
+
 type EngineDriver struct {
 	Log log.Logger
 	// API bindings to execution engine
-	RPC DriverAPI
-
+	RPC     DriverAPI
+	DL      Downloader
 	SyncRef SyncReference
 
 	// The current driving force, to shutdown before closing the engine.
@@ -25,184 +30,33 @@ type EngineDriver struct {
 	// There may only be 1 driver at a time
 	driveLock sync.Mutex
 
-	// Locks the L1 and L2 head changes, to keep a consistent view of the engine
-	headLock sync.RWMutex
-
-	// l1Head tracks the L1 block corresponding to the l2Head
-	l1Head eth.BlockID
-
-	// l2Head tracks the head-block of the engine
-	l2Head eth.BlockID
-
-	// l2Finalized tracks the block the engine can safely regard as irreversible
-	// (a week for disputes, or maybe shorter if we see L1 finalize and take the derived L2 chain up till there)
-	l2Finalized eth.BlockID
-
-	// The L1 block we are syncing towards, may be ahead of l1Head
-	l1Target eth.BlockID
-
-	// Genesis starting point
-	Genesis Genesis
+	EngineDriverState
 }
 
-// L1Head returns the block-id (hash and number) of the last L1 block that was derived into the L2 block
-func (e *EngineDriver) L1Head() eth.BlockID {
-	e.headLock.RLock()
-	defer e.headLock.RUnlock()
-	return e.l1Head
-}
-
-// L2Head returns the block-id (hash and number) of the L2 chain head
-func (e *EngineDriver) L2Head() eth.BlockID {
-	e.headLock.RLock()
-	defer e.headLock.RUnlock()
-	return e.l2Head
-}
-
-func (e *EngineDriver) Head() (l1Head eth.BlockID, l2Head eth.BlockID) {
-	e.headLock.RLock()
-	defer e.headLock.RUnlock()
-	return e.l1Head, e.l2Head
-}
-
-func (e *EngineDriver) UpdateHead(l1Head eth.BlockID, l2Head eth.BlockID) {
-	e.headLock.Lock()
-	defer e.headLock.Unlock()
-	e.l1Head = l1Head
-	e.l2Head = l2Head
-}
-
-func (e *EngineDriver) RequestHeadUpdate(ctx context.Context) error {
-	e.headLock.Lock()
-	defer e.headLock.Unlock()
-	refL1, refL2, _, err := e.SyncRef.RefByL2Num(ctx, nil, &e.Genesis)
-	if err != nil {
-		return err
-	}
-	e.l1Head = refL1
-	e.l2Head = refL2
-	return nil
-}
-
-func (e *EngineDriver) Drive(ctx context.Context, dl Downloader, l1Heads <-chan eth.HeadSignal) ethereum.Subscription {
+func (e *EngineDriver) Drive(ctx context.Context, l1Heads <-chan eth.HeadSignal) ethereum.Subscription {
 	e.driveLock.Lock()
 	defer e.driveLock.Unlock()
 	if e.driveSub != nil {
 		return e.driveSub
 	}
-	e.driveSub = event.NewSubscription(func(quit <-chan struct{}) error {
-		// keep making many sync steps if we can make sync progress
-		hot := time.Millisecond * 30
-		// check on sync regularly, but prioritize sync triggers with head updates etc.
-		cold := time.Second * 8
-		// at least try every minute to sync, even if things are going well
-		max := time.Minute
 
-		syncTicker := time.NewTicker(cold)
-		defer syncTicker.Stop()
-
-		// backoff sync attempts if we are not making progress
-		backoff := cold
-		syncQuickly := func() {
-			syncTicker.Reset(hot)
-			backoff = cold
-		}
-		// exponential backoff, add 10% each step, up to max.
-		syncBackoff := func() {
-			backoff += backoff / 10
-			if backoff > max {
-				backoff = max
-			}
-			syncTicker.Reset(backoff)
-		}
-
-		l2HeadPollTicker := time.NewTicker(time.Second * 14)
-		defer l2HeadPollTicker.Stop()
-
-		onL2Update := func() {
-			// When we updated L2, we want to continue sync quickly
-			syncQuickly()
-			// And we want to slow down requesting the L2 engine for its head (we just changed it ourselves)
-			// Request head if we don't successfully change it in the next 14 seconds.
-			l2HeadPollTicker.Reset(time.Second * 14)
-		}
-
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-quit:
-				return nil
-			case <-l2HeadPollTicker.C:
-				ctx, cancel := context.WithTimeout(ctx, time.Second*4)
-				if err := e.RequestHeadUpdate(ctx); err != nil {
-					e.Log.Error("failed to fetch L2 head info", "err", err)
-				}
-				cancel()
-				continue
-			case l1HeadSig := <-l1Heads:
-				if e.l1Head == l1HeadSig.Self {
-					e.Log.Debug("Received L1 head signal, already synced to it, ignoring event", "l1_head", e.l1Head)
-					continue
-				}
-				if e.l1Head == l1HeadSig.Parent {
-					// Simple extend, a linear life is easy
-					if l2ID, err := DriverStep(ctx, e.Log, e.RPC, dl, l1HeadSig.Self, e.l2Head, e.l2Finalized.Hash); err != nil {
-						e.Log.Error("Failed to extend L2 chain with new L1 block", "l1", l1HeadSig.Self, "l2", e.l2Head, "err", err)
-						// Retry sync later
-						e.l1Target = l1HeadSig.Self
-						onL2Update()
-						continue
-					} else {
-						e.UpdateHead(l1HeadSig.Self, l2ID)
-						continue
-					}
-				}
-				if e.l1Head.Number < l1HeadSig.Parent.Number {
-					e.Log.Debug("Received new L1 head, engine is out of sync, cannot immediately process", "l1", l1HeadSig.Self, "l2", e.l2Head)
-				} else {
-					e.Log.Warn("Received a L1 reorg, syncing new alternative chain", "l1", l1HeadSig.Self, "l2", e.l2Head)
-				}
-
-				e.l1Target = l1HeadSig.Self
-				syncQuickly()
-				continue
-			case <-syncTicker.C:
-				// If already synced, or in case of failure, we slow down
-				syncBackoff()
-				if e.l1Head == e.l1Target {
-					e.Log.Debug("Engine is fully synced", "l1_head", e.l1Head, "l2_head", e.l2Head)
-					// TODO: even though we are fully synced, it may be worth attempting anyway,
-					// in case the e.l1Head is not updating (failed/broken L1 head subscription)
-					continue
-				}
-				e.Log.Debug("finding next sync step, engine syncing", "l2", e.l2Head, "l1", e.l1Head)
-				nextRefL1, refL2, err := FindSyncStart(ctx, e.SyncRef, &e.Genesis)
-				if err != nil {
-					e.Log.Error("Failed to find sync starting point", "err", err)
-					continue
-				}
-				if nextRefL1 == e.l1Head {
-					e.Log.Debug("Engine is already synced, aborting sync", "l1_head", e.l1Head, "l2_head", e.l2Head)
-					continue
-				}
-				if l2ID, err := DriverStep(ctx, e.Log, e.RPC, dl, nextRefL1, refL2, e.l2Finalized.Hash); err != nil {
-					e.Log.Error("Failed to sync L2 chain with new L1 block", "l1", nextRefL1, "onto_l2", refL2, "err", err)
-					continue
-				} else {
-					e.UpdateHead(nextRefL1, l2ID) // l2ID is derived from the nextRefL1
-				}
-				// Successfully stepped toward target. Continue quickly if we are not there yet
-				if e.l1Head != e.l1Target {
-					onL2Update()
-				}
-			}
-		}
-	})
+	e.driveSub = event.NewSubscription(NewDriverLoop(ctx, &e.EngineDriverState, e.Log, l1Heads, e))
 	return e.driveSub
 }
 
+func (e *EngineDriver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL2 eth.BlockID, err error) {
+	refL1, refL2, _, err = e.SyncRef.RefByL2Num(ctx, nil, &e.Genesis)
+	return
+}
+
+func (e *EngineDriver) findSyncStart(ctx context.Context) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error) {
+	return FindSyncStart(ctx, e.SyncRef, &e.Genesis)
+}
+
+func (e *EngineDriver) driverStep(ctx context.Context, nextRefL1 eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error) {
+	return DriverStep(ctx, e.Log, e.RPC, e.DL, nextRefL1, refL2, finalized.Hash)
+}
+
 func (e *EngineDriver) Close() {
-	e.RPC.Close()
 	e.driveSub.Unsubscribe()
 }

--- a/opnode/l2/driver_loop.go
+++ b/opnode/l2/driver_loop.go
@@ -1,0 +1,76 @@
+package l2
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// keep making many sync steps if we can make sync progress
+const hot = time.Millisecond * 30
+
+// check on sync regularly, but prioritize sync triggers with head updates etc.
+const cold = time.Second * 8
+
+// at least try every minute to sync, even if things are going well
+const max = time.Minute
+
+func NewDriverLoop(ctx context.Context, state StateMachine, log log.Logger, l1Heads <-chan eth.HeadSignal, driver Driver) func(quit <-chan struct{}) error {
+
+	backoff := cold
+	syncTicker := time.NewTicker(cold)
+	l2HeadPoll := time.NewTicker(time.Second * 14)
+
+	// exponential backoff, add 10% each step, up to max.
+	syncBackoff := func() {
+		backoff += backoff / 10
+		if backoff > max {
+			backoff = max
+		}
+		syncTicker.Reset(backoff)
+	}
+	syncQuickly := func() {
+		syncTicker.Reset(hot)
+		backoff = cold
+	}
+	onL2Update := func() {
+		// And we want to slow down requesting the L2 engine for its head (we just changed it ourselves)
+		// Request head if we don't successfully change it in the next 14 seconds.
+		l2HeadPoll.Reset(time.Second * 14)
+	}
+	return func(quit <-chan struct{}) error {
+		defer syncTicker.Stop()
+		defer l2HeadPoll.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-quit:
+				return nil
+			case <-l2HeadPoll.C:
+				ctx, cancel := context.WithTimeout(ctx, time.Second*4)
+				if state.RequestUpdate(ctx, log, driver) {
+					onL2Update()
+				}
+				cancel()
+				continue
+			case l1HeadSig := <-l1Heads:
+				if state.NotifyL1Head(ctx, log, l1HeadSig, driver) {
+					syncQuickly()
+				}
+				continue
+			case <-syncTicker.C:
+				// If already synced, or in case of failure, we slow down
+				syncBackoff()
+				if state.RequestSync(ctx, log, driver) {
+					// Successfully stepped toward target. Continue quickly if we are not there yet
+					syncQuickly()
+					onL2Update()
+				}
+			}
+		}
+	}
+}

--- a/opnode/l2/driver_state.go
+++ b/opnode/l2/driver_state.go
@@ -1,0 +1,130 @@
+package l2
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type StateMachine interface {
+	RequestUpdate(ctx context.Context, log log.Logger, driver Driver) (l2Updated bool)
+	RequestSync(ctx context.Context, log log.Logger, driver Driver) (l2Updated bool)
+	NotifyL1Head(ctx context.Context, log log.Logger, l1HeadSig eth.HeadSignal, driver Driver) (l2Updated bool)
+}
+
+type EngineDriverState struct {
+	// Locks the L1 and L2 head changes, to keep a consistent view of the engine
+	headLock sync.RWMutex
+
+	// l1Head tracks the L1 block corresponding to the l2Head
+	l1Head eth.BlockID
+
+	// l2Head tracks the head-block of the engine
+	l2Head eth.BlockID
+
+	// l2Finalized tracks the block the engine can safely regard as irreversible
+	// (a week for disputes, or maybe shorter if we see L1 finalize and take the derived L2 chain up till there)
+	l2Finalized eth.BlockID
+
+	// The L1 block we are syncing towards, may be ahead of l1Head
+	l1Target eth.BlockID
+
+	// Genesis starting point
+	Genesis Genesis
+}
+
+// L1Head returns the block-id (hash and number) of the last L1 block that was derived into the L2 block
+func (e *EngineDriverState) L1Head() eth.BlockID {
+	e.headLock.RLock()
+	defer e.headLock.RUnlock()
+	return e.l1Head
+}
+
+// L2Head returns the block-id (hash and number) of the L2 chain head
+func (e *EngineDriverState) L2Head() eth.BlockID {
+	e.headLock.RLock()
+	defer e.headLock.RUnlock()
+	return e.l2Head
+}
+
+func (e *EngineDriverState) Head() (l1Head eth.BlockID, l2Head eth.BlockID) {
+	e.headLock.RLock()
+	defer e.headLock.RUnlock()
+	return e.l1Head, e.l2Head
+}
+
+func (e *EngineDriverState) UpdateHead(l1Head eth.BlockID, l2Head eth.BlockID) {
+	e.headLock.Lock()
+	defer e.headLock.Unlock()
+	e.l1Head = l1Head
+	e.l2Head = l2Head
+}
+
+func (e *EngineDriverState) RequestUpdate(ctx context.Context, log log.Logger, driver Driver) (l2Updated bool) {
+	refL1, refL2, err := driver.requestEngineHead(ctx)
+	if err != nil {
+		log.Error("failed to request engine head", "err", err)
+		return false
+	}
+	e.headLock.Lock()
+	defer e.headLock.Unlock()
+
+	e.l1Head = refL1
+	e.l2Head = refL2
+	return e.l1Head != refL1 || e.l2Head != refL2
+}
+
+func (e *EngineDriverState) RequestSync(ctx context.Context, log log.Logger, driver Driver) (l2Updated bool) {
+	if e.l1Head == e.l1Target {
+		log.Debug("Engine is fully synced", "l1_head", e.l1Head, "l2_head", e.l2Head)
+		// TODO: even though we are fully synced, it may be worth attempting anyway,
+		// in case the e.l1Head is not updating (failed/broken L1 head subscription)
+		return false
+	}
+	log.Debug("finding next sync step, engine syncing", "l2", e.l2Head, "l1", e.l1Head)
+	nextRefL1, refL2, err := driver.findSyncStart(ctx)
+	if err != nil {
+		log.Error("Failed to find sync starting point", "err", err)
+		return false
+	}
+	if nextRefL1 == e.l1Head {
+		log.Debug("Engine is already synced, aborting sync", "l1_head", e.l1Head, "l2_head", e.l2Head)
+		return false
+	}
+	if l2ID, err := driver.driverStep(ctx, nextRefL1, refL2, e.l2Finalized); err != nil {
+		log.Error("Failed to sync L2 chain with new L1 block", "l1", nextRefL1, "onto_l2", refL2, "err", err)
+		return false
+	} else {
+		e.UpdateHead(nextRefL1, l2ID) // l2ID is derived from the nextRefL1
+	}
+	return e.l1Head != e.l1Target
+}
+
+func (e *EngineDriverState) NotifyL1Head(ctx context.Context, log log.Logger, l1HeadSig eth.HeadSignal, driver Driver) (l2Updated bool) {
+	if e.l1Head == l1HeadSig.Self {
+		log.Debug("Received L1 head signal, already synced to it, ignoring event", "l1_head", e.l1Head)
+		return
+	}
+	if e.l1Head == l1HeadSig.Parent {
+		// Simple extend, a linear life is easy
+		if l2ID, err := driver.driverStep(ctx, l1HeadSig.Self, e.l2Head, e.l2Finalized); err != nil {
+			log.Error("Failed to extend L2 chain with new L1 block", "l1", l1HeadSig.Self, "l2", e.l2Head, "err", err)
+			// Retry sync later
+			e.l1Target = l1HeadSig.Self
+			return false
+		} else {
+			e.UpdateHead(l1HeadSig.Self, l2ID)
+			return true
+		}
+	}
+	if e.l1Head.Number < l1HeadSig.Parent.Number {
+		log.Debug("Received new L1 head, engine is out of sync, cannot immediately process", "l1", l1HeadSig.Self, "l2", e.l2Head)
+	} else {
+		log.Warn("Received a L1 reorg, syncing new alternative chain", "l1", l1HeadSig.Self, "l2", e.l2Head)
+	}
+
+	e.l1Target = l1HeadSig.Self
+	return false
+}

--- a/opnode/l2/driver_state.go
+++ b/opnode/l2/driver_state.go
@@ -8,9 +8,17 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// StateMachine provides control over the driver state, when given control over the Driver actions.
 type StateMachine interface {
+	// RequestUpdate tries to update the state-machine with the driver head information.
+	// If the state-machine changed, considering the engine L1 and L2 head, it will return true. False otherwise.
 	RequestUpdate(ctx context.Context, log log.Logger, driver Driver) (l2Updated bool)
+	// RequestSync tries to sync the provided driver towards the sync target of the state-machine.
+	// If the L2 syncs a step, but is not finished yet, it will return true. False otherwise.
 	RequestSync(ctx context.Context, log log.Logger, driver Driver) (l2Updated bool)
+	// NotifyL1Head updates the state-machine with the L1 signal,
+	// and attempts to sync the driver if the update extends the previous head.
+	// Returns true if the driver successfully derived and synced the L2 block to match L1. False otherwise.
 	NotifyL1Head(ctx context.Context, log log.Logger, l1HeadSig eth.HeadSignal, driver Driver) (l2Updated bool)
 }
 

--- a/opnode/l2/driver_state_test.go
+++ b/opnode/l2/driver_state_test.go
@@ -1,0 +1,111 @@
+package l2
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type testID string
+
+func (id testID) ID() eth.BlockID {
+	parts := strings.Split(string(id), ":")
+	if len(parts) != 2 {
+		panic("bad id")
+	}
+	if len(parts[0]) > 32 {
+		panic("test ID hash too long")
+	}
+	var h common.Hash
+	copy(h[:], parts[0])
+	v, err := strconv.ParseUint(parts[1], 0, 64)
+	if err != nil {
+		panic(err)
+	}
+	return eth.BlockID{
+		Hash:   h,
+		Number: v,
+	}
+}
+
+type testState struct {
+	l1Head      testID
+	l2Head      testID
+	l2Finalized testID
+	l1Target    testID
+	genesisL1   testID
+	genesisL2   testID
+}
+
+func makeState(st testState) *EngineDriverState {
+	return &EngineDriverState{
+		l1Head:      st.l1Head.ID(),
+		l2Head:      st.l2Head.ID(),
+		l2Finalized: st.l2Finalized.ID(),
+		l1Target:    st.l1Target.ID(),
+		Genesis: Genesis{
+			L1: st.genesisL1.ID(),
+			L2: st.genesisL2.ID(),
+		},
+	}
+}
+
+type mockDriver struct {
+	mock.Mock
+}
+
+func (m *mockDriver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL2 eth.BlockID, err error) {
+	returnArgs := m.Called(ctx)
+	refL1 = returnArgs.Get(0).(eth.BlockID)
+	refL2 = returnArgs.Get(1).(eth.BlockID)
+	err = returnArgs.Get(2).(error)
+	return
+}
+
+func (m *mockDriver) findSyncStart(ctx context.Context) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error) {
+	returnArgs := m.Called(ctx)
+	nextRefL1 = returnArgs.Get(0).(eth.BlockID)
+	refL2 = returnArgs.Get(1).(eth.BlockID)
+	err, _ = returnArgs.Get(2).(error)
+	return
+}
+
+func (m *mockDriver) driverStep(ctx context.Context, nextRefL1 eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error) {
+	returnArgs := m.Called(ctx, nextRefL1, refL2, finalized)
+	l2ID = returnArgs.Get(0).(eth.BlockID)
+	err, _ = returnArgs.Get(1).(error)
+	return
+}
+
+var _ Driver = (*mockDriver)(nil)
+
+func TestEngineDriverState_RequestSync(t *testing.T) {
+	log := testlog.Logger(t, log.LvlTrace)
+	driver := new(mockDriver)
+	ctx := context.Background()
+
+	state := makeState(testState{
+		l1Head:      "c:2",
+		l2Head:      "C:2",
+		l2Finalized: "B:1",
+		l1Target:    "e:4",
+		genesisL1:   "a:0",
+		genesisL2:   "b:0",
+	})
+	driver.On("findSyncStart", ctx).Return(testID("d:3").ID(), testID("C:2").ID(), nil)
+	driver.On("driverStep", ctx, testID("d:3").ID(), testID("C:2").ID(), testID("B:1").ID()).Return(testID("D:3").ID(), nil)
+
+	l2Updated := state.RequestSync(ctx, log, driver)
+
+	assert.Equal(t, state.l1Head, testID("d:3").ID())
+	assert.Equal(t, state.l2Head, testID("D:3").ID())
+	assert.True(t, l2Updated)
+}

--- a/opnode/l2/sync_start.go
+++ b/opnode/l2/sync_start.go
@@ -15,7 +15,8 @@ var WrongChainErr = errors.New("wrong chain")
 
 // FindSyncStart finds nextRefL1: the L1 block needed next for sync, to derive into a L2 block on top of refL2.
 // If the L1 reorgs then this will find the common history to build on top of and then follow the first step of the reorg.
-func FindSyncStart(ctx context.Context, reference SyncReference, genesis *Genesis) (refL1, nextRefL1, refL2 eth.BlockID, err error) {
+func FindSyncStart(ctx context.Context, reference SyncReference, genesis *Genesis) (nextRefL1, refL2 eth.BlockID, err error) {
+	var refL1 eth.BlockID    // the L1 block the refL2 was derived from
 	var parentL2 common.Hash // the parent of refL2
 	// Start at L2 head
 	refL1, refL2, parentL2, err = reference.RefByL2Num(ctx, nil, genesis)

--- a/opnode/l2/sync_start_test.go
+++ b/opnode/l2/sync_start_test.go
@@ -139,7 +139,7 @@ func (c *syncStartTestCase) Run(t *testing.T) {
 	}
 	expectedRefL2 := mockID(c.ExpectedRefL2, expectedRefL2Num)
 
-	_, nextRefL1, refL2, err := FindSyncStart(context.Background(), msr, genesis)
+	nextRefL1, refL2, err := FindSyncStart(context.Background(), msr, genesis)
 	if c.ExpectedErr != nil {
 		assert.Error(t, err, "got next L1 %s (%d), onto L2: %s (%d)", nextRefL1.Hash[:1], nextRefL1.Number, refL2.Hash[:1], refL2.Number)
 		assert.ErrorIs(t, err, c.ExpectedErr)

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -92,7 +92,7 @@ These are then encoded as a [L1 attributes deposit] to update the [L1 Attributes
 A [transaction deposit][transaction deposits] is an L2 transaction that has been submitted on L1, via a call to the
 [deposit feed contract].
 
-Refer to the[**deposit feed contract specification**][deposit-feed-spec] for details on how
+Refer to the [**deposit feed contract specification**][deposit-feed-spec] for details on how
 deposit properties are emitted in deposit log entries.
 
 [deposit-feed-spec]: deposits.md#deposit-feed-contract


### PR DESCRIPTION
Part of #119: staging -> main migration

This:
- `EngineDriver` is like a binding to a remote engine, tracking to where it's synced.
- `Drive` is a sync process that can be started/shutdown **per remote engine**, and responds to head events from L1, and syncs (happy extend-case, or worst-case sync with reorg) the L2 chain by running a driver-step on the right starting-point. There is only a single active driving process at a time per engine.

**Depends on #130**

Review: any team, systems team preferred.

Spec: Do we want to go-indepth, like back-off strategy and failure-cases of sync in the spec? Or maybe just the "if out of sync, run a driver-step on with L1 block `X_n` and L2 block parent `Y_{n-1}`" summary of driver routine behavior? (we already more or less have the latter)

Testing: this is the most time/event/integration heavy of all of the reference implementation. Only a single event hub, but still challenging to unit-test. It works e2e though. Any suggestions/help how to best test this?
