### PR TITLE
Add code coverage reporting for go in CI

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -25,5 +25,7 @@ jobs:
           skip-go-installation: true
           # rules: https://golangci-lint.run/usage/quick-start/
           args: -E asciicheck,goimports
-      - name: Test
-        run: go test ./...
+      - name: Test and generate coverage
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Upload coverage output
+        uses: codecov/codecov-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn-error.log
+coverage.out


### PR DESCRIPTION
Adds test coverage reports using CodeCov. 

They will appear here: https://app.codecov.io/gh/ethereum-optimism/optimistic-specs