### PR TITLE
ci: golang linting and testing

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -25,5 +25,7 @@ jobs:
           skip-go-installation: true
           # rules: https://golangci-lint.run/usage/quick-start/
           args: -E asciicheck,goimports
-      - name: Test
-        run: go test ./...
+      - name: Test and generate coverage
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Upload coverage output
+        uses: codecov/codecov-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 yarn-error.log
+coverage.out
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/ethereum-optimism/optimistic-specs/branch/main/graph/badge.svg?token=19JPIN9XPB)](https://codecov.io/gh/ethereum-optimism/optimistic-specs)
+
 # The Optimism Spec
 
 This repository holds the work-in-progress specification for the next version of


### PR DESCRIPTION
This PR just moves the CI setup changes from `staging` to `main` so that we will have access to them while reviewing the PRs currently in review which are against `main`: #119.