### PR TITLE
ref impl: reduce command running boilerplate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.13
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
 	github.com/holiman/uint256 v1.2.0
-	github.com/protolambda/ask v0.1.2
+	github.com/protolambda/ask v0.1.3
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1 h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/protolambda/ask v0.1.2 h1:BSQP7VDmh+L0lLFjEYUMrTnb2SwdT64UY3vXqDuIIok=
-github.com/protolambda/ask v0.1.2/go.mod h1:7WB3T4BXZhKUaDcEjF7Ksgi7HCrBDxM37gyM1EhwkmM=
+github.com/protolambda/ask v0.1.3 h1:DhROikobv9hgj6zUh9svByFvzvsAHvDSzjwsGDMYAu8=
+github.com/protolambda/ask v0.1.3/go.mod h1:7WB3T4BXZhKUaDcEjF7Ksgi7HCrBDxM37gyM1EhwkmM=
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
 github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeCE=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=

--- a/opnode/cmd/main.go
+++ b/opnode/cmd/main.go
@@ -1,13 +1,6 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"io"
-	"os"
-	"os/signal"
-	"time"
-
 	"github.com/ethereum-optimism/optimistic-specs/opnode/node"
 	"github.com/protolambda/ask"
 )
@@ -33,67 +26,6 @@ func (c *MainCmd) Routes() []string {
 	return []string{"run"}
 }
 
-type start struct {
-	cmd *ask.CommandDescription
-	err error
-}
-
 func main() {
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
-	ctx, cancel := context.WithCancel(context.Background())
-
-	cmd := &MainCmd{}
-	descr, err := ask.Load(cmd)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "failed to load main command: %v", err.Error())
-		os.Exit(1)
-	}
-	onDeprecated := func(fl ask.PrefixedFlag) error {
-		fmt.Fprintf(os.Stderr, "warning: flag %q is deprecated: %s", fl.Path, fl.Deprecated)
-		return nil
-	}
-
-	starter := make(chan start)
-
-	// run command in the background, so we can stop it at any time
-	go func() {
-		cmd, err := descr.Execute(ctx, &ask.ExecutionOptions{OnDeprecated: onDeprecated}, os.Args[1:]...)
-		starter <- start{cmd, err}
-	}()
-
-	for {
-		select {
-		case start := <-starter:
-			if cmd, err := start.cmd, start.err; err == nil {
-				// if the command is long-running and closeable later on, then have the interrupt close it.
-				if cl, ok := cmd.Command.(io.Closer); ok {
-					<-interrupt
-					err := cl.Close()
-					cancel()
-					if err != nil {
-						_, _ = fmt.Fprintf(os.Stderr, "failed to close node gracefully. Exiting in 5 seconds. %v", err.Error())
-						<-time.After(time.Second * 5)
-						os.Exit(1)
-					}
-					os.Exit(0)
-				} else {
-					os.Exit(0)
-				}
-			} else if err == ask.UnrecognizedErr {
-				_, _ = fmt.Fprintln(os.Stderr, err)
-				os.Exit(1)
-			} else if err == ask.HelpErr {
-				_, _ = fmt.Fprintln(os.Stderr, cmd.Usage(false))
-				os.Exit(0)
-			} else {
-				_, _ = fmt.Fprintln(os.Stderr, err.Error())
-				os.Exit(1)
-			}
-		case <-interrupt: // if interrupted during start, then we try to cancel
-			cancel()
-			// TODO: multiple interrupts to force quick exit?
-		}
-	}
-
+	ask.Run(new(MainCmd))
 }


### PR DESCRIPTION
The start, command parsing, shutdown handling, etc. is a lot of boilerplate that is common between all usages of `ask`, so I moved it into the library as convenience method.