### PR TITLE
opnode: Add Dockerfile/Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ coverage.out
 
 # hardhat automatically puts console.sol in here when you use it
 .deps
+
+# built binaries
+bin

--- a/Dockerfile.opnode
+++ b/Dockerfile.opnode
@@ -1,0 +1,16 @@
+FROM golang:1.17.3-alpine3.13 as builder
+
+RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
+
+COPY Makefile /app/Makefile
+COPY go.mod /app/go.mod
+COPY go.sum /app/go.sum
+
+WORKDIR /app
+COPY ./opnode /app/opnode
+RUN make
+
+FROM alpine:3.13
+
+COPY --from=builder /app/bin/op /usr/local/bin
+CMD ["op"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+opnode:
+	go build -o ./bin/op ./opnode/cmd
+.PHONY: opnode
+
+clean:
+	rm -rf ./bin
+.PHONY: clean


### PR DESCRIPTION
- Adds a Dockerfile so that we can build opnode images
- Adds a Makefile to make building the opnode easier
