### PR TITLE
chore: add basic editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+# defaults
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[*.{ts,js}]
+indent_size = 2


### PR DESCRIPTION
**Description**

Adds a basic `.editorConfig`, identical to the one in the [monorepo](https://github.com/ethereum-optimism/optimism/blob/d10e31996aca39bc9529dcbe69a57aa46e6a84e9/.editorconfig#L1). 

This will pretty much eliminate any issues with extra whitespace creeping in at EOL, resulting in 'dirty' commits.

Many editors will inherit settings from this file, but VSCode requires an [extension](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) to support it. 

Learn more: https://editorconfig.org/.
