### PR TITLE
rollup: implement sequencing-window based derivation

### DIFF
--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -57,7 +57,7 @@ func (e *EngineDriver) Drive(ctx context.Context, l1Heads <-chan eth.HeadSignal)
 }
 
 func (e *EngineDriver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL2 eth.BlockID, err error) {
-	refL1, refL2, _, err = e.SyncRef.RefByL2Num(ctx, nil, &e.Genesis)
+	refL1, refL2, _, err = e.SyncRef.RefByL2Num(ctx, nil, &e.Config.Genesis)
 	return
 }
 

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
 	"sync"
 
 	"github.com/ethereum/go-ethereum"
@@ -18,14 +19,17 @@ type Driver interface {
 	// requestEngineHead retrieves the L2 head reference of the engine, as well as the L1 reference it was derived from.
 	// An error is returned when the L2 head information could not be retrieved (timeout or connection issue)
 	requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL2 eth.BlockID, err error)
+	// TODO: return buffer of L1 blocks, do seq-window slicing in caller instead
+	// TODO update description
 	// findSyncStart statelessly finds the next L1 block to derive, and on which L2 block it applies.
 	// If the engine is fully synced, then the last derived L1 block, and parent L2 block, is repeated.
 	// An error is returned if the sync starting point could not be determined (due to timeouts, wrong-chain, etc.)
-	findSyncStart(ctx context.Context) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error)
-	// driverStep explicitly calls the engine to derive a L1 block into a L2 block, and apply it on top of the given L2 block.
+	findSyncStart(ctx context.Context) (nextL1SeqWindow []eth.BlockID, refL2 eth.BlockID, l2Time uint64, err error)
+	// driverStep explicitly calls the engine to derive a sequencing window of L1 blocks into L2 blocks,
+	// and apply it on top of the given L2 block, starting at the given l2Time.
 	// The finalized L2 block is provided to update the engine with finality, but does not affect the derivation step itself.
 	// The resulting L2 block ID is returned, or an error if the derivation fails.
-	driverStep(ctx context.Context, nextRefL1 eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error)
+	driverStep(ctx context.Context, nextL1SeqWindow []eth.BlockID, refL2 eth.BlockID, l2Time uint64, finalized eth.BlockID) (l2ID eth.BlockID, err error)
 }
 
 type EngineDriver struct {
@@ -34,6 +38,7 @@ type EngineDriver struct {
 	RPC     DriverAPI
 	DL      Downloader
 	SyncRef rollupSync.SyncReference
+	Conf    *rollup.Config
 
 	// The current driving force, to shutdown before closing the engine.
 	driveSub ethereum.Subscription
@@ -59,12 +64,16 @@ func (e *EngineDriver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID
 	return
 }
 
-func (e *EngineDriver) findSyncStart(ctx context.Context) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error) {
-	return rollupSync.FindSyncStart(ctx, e.SyncRef, &e.Genesis)
+func (e *EngineDriver) findSyncStart(ctx context.Context) (nextL1SeqWindow []eth.BlockID, refL2 eth.BlockID, l2Time uint64, err error) {
+	// TODO: update sync start algo
+	// TODO: maybe change interface to return more than a sequence window, and start slicing windows from that in the driver,
+	// so we can buffer the expected L1 input block IDs, and maybe even pre-fetch the L1 blocks to make sync faster.
+	//return rollupSync.FindSyncStart(ctx, e.SyncRef, &e.Genesis)
+	return
 }
 
-func (e *EngineDriver) driverStep(ctx context.Context, nextRefL1 eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error) {
-	return DriverStep(ctx, e.Log, e.RPC, e.DL, nextRefL1, refL2, finalized.Hash)
+func (e *EngineDriver) driverStep(ctx context.Context, nextL1SeqWindow []eth.BlockID, refL2 eth.BlockID, l2Time uint64, finalized eth.BlockID) (l2ID eth.BlockID, err error) {
+	return DriverStep(ctx, e.Log, e.Conf, e.RPC, e.DL, nextL1SeqWindow, refL2, l2Time, finalized.Hash)
 }
 
 func (e *EngineDriver) Close() {

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -62,11 +62,7 @@ func (e *EngineDriver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID
 }
 
 func (e *EngineDriver) findSyncStart(ctx context.Context) (nextL1s []eth.BlockID, refL2 eth.BlockID, err error) {
-	// TODO: update sync start algo
-	// TODO: maybe change interface to return more than a sequence window, and start slicing windows from that in the driver,
-	// so we can buffer the expected L1 input block IDs, and maybe even pre-fetch the L1 blocks to make sync faster.
-	//return rollupSync.FindSyncStart(ctx, e.SyncRef, &e.Genesis)
-	return
+	return rollupSync.FindSyncStart(ctx, e.SyncRef, &e.Genesis)
 }
 
 func (e *EngineDriver) driverStep(ctx context.Context, seqWindow []eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error) {

--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -93,22 +93,25 @@ func (e *EngineDriverState) RequestSync(ctx context.Context, log log.Logger, dri
 		return false
 	}
 	log.Debug("finding next sync step, engine syncing", "l2", e.l2Head, "l1", e.l1Head)
-	nextL1SeqWindow, refL2, l2Time, err := driver.findSyncStart(ctx)
+	nextL1s, refL2, err := driver.findSyncStart(ctx)
 	if err != nil {
 		log.Error("Failed to find sync starting point", "err", err)
 		return false
 	}
+	// TODO: buffer nextL1s
+	// TODO: slice correct seq window
+	seqWindow := nextL1s
 	// TODO adjust sync check
-	if nextL1SeqWindow[0] == e.l1Head {
+	if seqWindow[0] == e.l1Head {
 		log.Debug("Engine is already synced, aborting sync", "l1_head", e.l1Head, "l2_head", e.l2Head)
 		return false
 	}
-	if l2ID, err := driver.driverStep(ctx, nextL1SeqWindow, refL2, l2Time, e.l2Finalized); err != nil {
-		log.Error("Failed to sync L2 chain with new L1 block", "l1_window", nextL1SeqWindow, "onto_l2", refL2, "err", err)
+	if l2ID, err := driver.driverStep(ctx, seqWindow, refL2, e.l2Finalized); err != nil {
+		log.Error("Failed to sync L2 chain with new L1 block", "l1_window", seqWindow, "onto_l2", refL2, "err", err)
 		return false
 	} else {
-		nextRefL1 := nextL1SeqWindow[0] // TODO: we should keep a buffer of L1 and slice the window out of it, instead of returning the window from findSyncStart
-		e.UpdateHead(nextRefL1, l2ID)   // l2ID is derived from the nextRefL1
+		nextRefL1 := seqWindow[0]     // TODO: we should keep a buffer of L1 and slice the window out of it
+		e.UpdateHead(nextRefL1, l2ID) // l2ID is derived from the nextRefL1
 	}
 	return e.l1Head != e.l1Target
 }
@@ -121,7 +124,7 @@ func (e *EngineDriverState) NotifyL1Head(ctx context.Context, log log.Logger, l1
 	if e.l1Head == l1HeadSig.Parent {
 		// Simple extend, a linear life is easy
 		// TODO: slice window based on l1HeadSig.Self, and select l2Time
-		if l2ID, err := driver.driverStep(ctx, nil, e.l2Head, 0, e.l2Finalized); err != nil {
+		if l2ID, err := driver.driverStep(ctx, nil, e.l2Head, e.l2Finalized); err != nil {
 			log.Error("Failed to extend L2 chain with new L1 block", "l1", l1HeadSig.Self, "l2", e.l2Head, "err", err)
 			// Retry sync later
 			e.l1Target = l1HeadSig.Self

--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -37,11 +37,17 @@ type EngineDriverState struct {
 	// (a week for disputes, or maybe shorter if we see L1 finalize and take the derived L2 chain up till there)
 	l2Finalized eth.BlockID
 
+	// l1Next buffers the next L1 block IDs to derive new L2 blocks from, with increasing block height.
+	l1Next []eth.BlockID
+	// l2NextParent buffers the L2 Block ID to build on with l1Next.
+	// This may not be in sync with the l2Head in case of reorgs.
+	l2NextParent eth.BlockID
+
 	// The L1 block we are syncing towards, may be ahead of l1Head
 	l1Target eth.BlockID
 
-	// Genesis starting point
-	Genesis rollup.Genesis
+	// Rollup config
+	Config rollup.Config
 }
 
 // L1Head returns the block-id (hash and number) of the last L1 block that was derived into the L2 block
@@ -86,34 +92,57 @@ func (e *EngineDriverState) RequestUpdate(ctx context.Context, log log.Logger, d
 }
 
 func (e *EngineDriverState) RequestSync(ctx context.Context, log log.Logger, driver Driver) (l2Updated bool) {
+	log = log.New("l1_head", e.l1Head, "l2_head", e.l2Head)
 	if e.l1Head == e.l1Target {
-		log.Debug("Engine is fully synced", "l1_head", e.l1Head, "l2_head", e.l2Head)
+		log.Debug("Engine is fully synced")
 		// TODO: even though we are fully synced, it may be worth attempting anyway,
 		// in case the e.l1Head is not updating (failed/broken L1 head subscription)
 		return false
 	}
-	log.Debug("finding next sync step, engine syncing", "l2", e.l2Head, "l1", e.l1Head)
-	nextL1s, refL2, err := driver.findSyncStart(ctx)
-	if err != nil {
-		log.Error("Failed to find sync starting point", "err", err)
+	// If the engine is not in sync with our previous sync preparation, then we need to reconstruct the buffered L1 ids
+	if e.l2Head != e.l2NextParent {
+		log.Debug("finding next sync step, engine syncing", "buffered_l2", e.l2NextParent)
+		nextL1s, refL2, err := driver.findSyncStart(ctx)
+		if err != nil {
+			log.Error("Failed to find sync starting point", "err", err)
+			return false
+		}
+		e.l1Next = nextL1s
+		e.l2NextParent = refL2
+	} else {
+		log.Debug("attempting new sync step")
+	}
+
+	return e.applyNextWindow(ctx, log, driver)
+}
+
+func (e *EngineDriverState) applyNextWindow(ctx context.Context, log log.Logger, driver Driver) (l2Updated bool) {
+	// If the engine moved faster than our buffer try to move the buffer forward, do not get stuck.
+	for i, id := range e.l1Next {
+		if e.l1Head == id {
+			log.Debug("Engine is ahead of rollup node, skipping forward and aborting sync")
+			e.l1Next = e.l1Next[i+1:]
+			e.l2NextParent = e.l2Head
+			return true
+		}
+	}
+	if uint64(len(e.l1Next)) < e.Config.SeqWindowSize {
+		log.Warn("Not enough known L1 blocks for sequencing window, skipping sync")
 		return false
 	}
-	// TODO: buffer nextL1s
-	// TODO: slice correct seq window
-	seqWindow := nextL1s
-	// TODO adjust sync check
-	if seqWindow[0] == e.l1Head {
-		log.Debug("Engine is already synced, aborting sync", "l1_head", e.l1Head, "l2_head", e.l2Head)
-		return false
-	}
-	if l2ID, err := driver.driverStep(ctx, seqWindow, refL2, e.l2Finalized); err != nil {
-		log.Error("Failed to sync L2 chain with new L1 block", "l1_window", seqWindow, "onto_l2", refL2, "err", err)
+	seqWindow := e.l1Next[:e.Config.SeqWindowSize]
+	log = log.New("l1_window_start", seqWindow[0], "onto_l2", e.l2NextParent)
+	if l2ID, err := driver.driverStep(ctx, seqWindow, e.l2NextParent, e.l2Finalized); err != nil {
+		log.Error("Failed to sync L2 chain with new L1 block", "stopped_at", l2ID, "err", err)
 		return false
 	} else {
-		nextRefL1 := seqWindow[0]     // TODO: we should keep a buffer of L1 and slice the window out of it
-		e.UpdateHead(nextRefL1, l2ID) // l2ID is derived from the nextRefL1
+		log.Debug("Finished driver step", "l1_head", seqWindow[0], "l2_head", l2ID)
+		e.UpdateHead(seqWindow[0], l2ID) // l2ID is derived from the nextRefL1
+		// shift sequencing window: batches overlap, but we continue deposit/l1info processing from the next block.
+		e.l1Next = e.l1Next[1:]
+		e.l2NextParent = l2ID
+		return true
 	}
-	return e.l1Head != e.l1Target
 }
 
 func (e *EngineDriverState) NotifyL1Head(ctx context.Context, log log.Logger, l1HeadSig eth.HeadSignal, driver Driver) (l2Updated bool) {
@@ -121,25 +150,19 @@ func (e *EngineDriverState) NotifyL1Head(ctx context.Context, log log.Logger, l1
 		log.Debug("Received L1 head signal, already synced to it, ignoring event", "l1_head", e.l1Head)
 		return
 	}
-	if e.l1Head == l1HeadSig.Parent {
-		// Simple extend, a linear life is easy
-		// TODO: slice window based on l1HeadSig.Self, and select l2Time
-		if l2ID, err := driver.driverStep(ctx, nil, e.l2Head, e.l2Finalized); err != nil {
-			log.Error("Failed to extend L2 chain with new L1 block", "l1", l1HeadSig.Self, "l2", e.l2Head, "err", err)
-			// Retry sync later
-			e.l1Target = l1HeadSig.Self
-			return false
-		} else {
-			e.UpdateHead(l1HeadSig.Self, l2ID)
-			return true
+	e.l1Target = l1HeadSig.Self
+	// Check if this is a simple extension on top of previous buffered L1 chain we already know of
+	if len(e.l1Next) > 0 && e.l1Next[len(e.l1Next)-1] == l1HeadSig.Parent {
+		// don't buffer more than 20 sequencing windows  (TBD, sanity limit)
+		if uint64(len(e.l1Next)) < e.Config.SeqWindowSize*20 {
+			e.l1Next = append(e.l1Next, l1HeadSig.Self)
 		}
+		return e.applyNextWindow(ctx, log, driver)
 	}
 	if e.l1Head.Number < l1HeadSig.Parent.Number {
 		log.Debug("Received new L1 head, engine is out of sync, cannot immediately process", "l1", l1HeadSig.Self, "l2", e.l2Head)
 	} else {
 		log.Warn("Received a L1 reorg, syncing new alternative chain", "l1", l1HeadSig.Self, "l2", e.l2Head)
 	}
-
-	e.l1Target = l1HeadSig.Self
 	return false
 }

--- a/opnode/rollup/driver/state_test.go
+++ b/opnode/rollup/driver/state_test.go
@@ -71,16 +71,16 @@ func (m *mockDriver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID, 
 	return
 }
 
-func (m *mockDriver) findSyncStart(ctx context.Context) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error) {
+func (m *mockDriver) findSyncStart(ctx context.Context) (nextL1s []eth.BlockID, refL2 eth.BlockID, err error) {
 	returnArgs := m.Called(ctx)
-	nextRefL1 = returnArgs.Get(0).(eth.BlockID)
+	nextL1s = returnArgs.Get(0).([]eth.BlockID)
 	refL2 = returnArgs.Get(1).(eth.BlockID)
 	err, _ = returnArgs.Get(2).(error)
 	return
 }
 
-func (m *mockDriver) driverStep(ctx context.Context, nextRefL1 eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error) {
-	returnArgs := m.Called(ctx, nextRefL1, refL2, finalized)
+func (m *mockDriver) driverStep(ctx context.Context, seqWindow []eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error) {
+	returnArgs := m.Called(ctx, seqWindow, refL2, finalized)
 	l2ID = returnArgs.Get(0).(eth.BlockID)
 	err, _ = returnArgs.Get(1).(error)
 	return
@@ -101,8 +101,8 @@ func TestEngineDriverState_RequestSync(t *testing.T) {
 		genesisL1:   "a:0",
 		genesisL2:   "b:0",
 	})
-	driver.On("findSyncStart", ctx).Return(testID("d:3").ID(), testID("C:2").ID(), nil)
-	driver.On("driverStep", ctx, testID("d:3").ID(), testID("C:2").ID(), testID("B:1").ID()).Return(testID("D:3").ID(), nil)
+	driver.On("findSyncStart", ctx).Return([]eth.BlockID{testID("d:3").ID()}, testID("C:2").ID(), nil)
+	driver.On("driverStep", ctx, []eth.BlockID{testID("d:3").ID()}, testID("C:2").ID(), testID("B:1").ID()).Return(testID("D:3").ID(), nil)
 
 	l2Updated := state.RequestSync(ctx, log, driver)
 

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -78,6 +78,7 @@ func DriverStep(ctx context.Context, log log.Logger, rpc DriverAPI,
 	}
 	logger.Debug("fetched L1 data for driver")
 
+	// TODO: update args
 	attrs, err := derive.PayloadAttributes(bl, receipts)
 	if err != nil {
 		return eth.BlockID{}, fmt.Errorf("failed to derive execution payload inputs: %v", err)

--- a/opnode/rollup/sync/start.go
+++ b/opnode/rollup/sync/start.go
@@ -14,9 +14,83 @@ import (
 
 var WrongChainErr = errors.New("wrong chain")
 
-// FindSyncStart finds nextRefL1: the L1 block needed next for sync, to derive into a L2 block on top of refL2.
+func V2FindSyncStart(ctx context.Context, reference SyncReference, genesis *rollup.Genesis) (nextL1s []eth.BlockID, refL2 eth.BlockID, err error) {
+	// Start the search for a matching chain between L1 and L2 with the L2 head
+	refL1, refL2, parentL2, err := reference.RefByL2Num(ctx, nil, genesis)
+	if err != nil {
+		return nil, eth.BlockID{}, fmt.Errorf("failed to fetch L2 head: %v", err)
+	}
+
+	maxBuffer := uint64(100)
+
+	// holds the traversed L1 hashes in a circular buffer, to build nextL1s from, as far as we can
+	cachedL1s := make([]eth.BlockID, maxBuffer)
+	// we cannot use the cache beyond the first block we fill it with, or any reorg or missing block we find along the way
+	minCacheL1Num := refL1.Number + 1
+	var currentL1, parentL1 eth.BlockID
+	for i := refL1.Number; i > genesis.L1.Number; i-- {
+		prevParent := parentL1
+		// 1: check if L1 has it (by number)
+		currentL1, parentL1, err = reference.RefByL1Num(ctx, refL1.Number)
+		if err != nil {
+			if !errors.Is(err, ethereum.NotFound) {
+				return nil, eth.BlockID{}, fmt.Errorf("failed to lookup block %d in L1: %w", refL1.Number, err)
+			}
+			// L1 doesn't have it, keep going
+			// Don't recognize this or later hashes by number though, it may have been reorged.
+			minCacheL1Num = i
+		} else {
+			// If this does not align with later blocks, then don't recognize the later blocks
+			if prevParent != (eth.BlockID{}) && prevParent != currentL1 {
+				minCacheL1Num = i + 1 // +1 because we can still recognize the current block
+			}
+			if currentL1 == refL1 {
+				break
+			}
+		}
+		// buffer actual L1
+		cachedL1s[i%maxBuffer] = currentL1
+
+		// continue with next L2 block
+		refL1, refL2, parentL2, err = reference.RefByL2Hash(ctx, parentL2, genesis)
+		if err != nil {
+			// TODO: re-attempt look-up, now that we already traversed previous history?
+			err = fmt.Errorf("failed to lookup block %s in L2: %w", refL2, err) // refL2 is previous parentL2
+			return
+		}
+	}
+	// if we have different genesis, then stop
+	if (refL2.Number <= genesis.L2.Number && refL2.Hash != genesis.L2.Hash) ||
+		(refL1.Number <= genesis.L1.Number && refL1.Hash != genesis.L1.Hash) {
+		return nil, genesis.L2, fmt.Errorf("cannot find L1 blocks building on L2 genesis")
+	}
+
+	// Collect the L1 chain that builds on the common point, to derive new L2 blocks from.
+	nextL1s = make([]eth.BlockID, 1, maxBuffer)
+	nextL1s[0] = refL1
+	// 3: walk forward L1 from common point to get nextL1s
+	for i := uint64(1); i < maxBuffer; i++ {
+		// if it's at or before the first L1 block we tried to match, then we cached it
+		if nextL1s[0].Number+i < minCacheL1Num {
+			nextL1s = append(nextL1s, cachedL1s[i%maxBuffer])
+		} else {
+			currentL1, parentL1, err = reference.RefByL1Num(ctx, nextL1s[0].Number+i)
+			if nextL1s[i-1] != parentL1 { // check if it extends the last block
+				// even though we hit an error (e.g. commonly block not found),
+				// there is no need to error, we just return less results,
+				// to avoid an inconsistent nextL1s list.
+				break
+			}
+			nextL1s = append(nextL1s, currentL1)
+		}
+	}
+	// skip the first L1 block that we already have in common
+	return nextL1s[1:], refL2, nil
+}
+
+// FindSyncStart finds nextL1s: the L1 blocks needed next for sync, to derive into a L2 block on top of refL2.
 // If the L1 reorgs then this will find the common history to build on top of and then follow the first step of the reorg.
-func FindSyncStart(ctx context.Context, reference SyncReference, genesis *rollup.Genesis) (nextRefL1, refL2 eth.BlockID, err error) {
+func FindSyncStart(ctx context.Context, reference SyncReference, genesis *rollup.Genesis) (nextL1s []eth.BlockID, refL2 eth.BlockID, err error) {
 	var refL1 eth.BlockID    // the L1 block the refL2 was derived from
 	var parentL2 common.Hash // the parent of refL2
 	// Start at L2 head
@@ -40,8 +114,9 @@ func FindSyncStart(ctx context.Context, reference SyncReference, genesis *rollup
 		currentL1 = eth.BlockID{} // empty = not found
 	}
 	if currentL1 == refL1 {
+		// TODO: try get the next N blocks, instead of next 1 ...
 		// L1 node has head-block of execution-engine, so we should fetch the L1 block that builds on top.
-		var ontoL1 eth.BlockID // ontoL1 is the parent, to make sure we got a nextRefL1 that connects as expected.
+		var nextRefL1, ontoL1 eth.BlockID // ontoL1 is the parent, to make sure we got a nextRefL1 that connects as expected.
 		nextRefL1, ontoL1, err = reference.RefByL1Num(ctx, refL1.Number+1)
 		if err != nil {
 			// If refL1 is the head block, then we might not have a next block to build on the head
@@ -57,6 +132,7 @@ func FindSyncStart(ctx context.Context, reference SyncReference, genesis *rollup
 			}
 			return
 		}
+		nextL1s = append(nextL1s, nextRefL1)
 		// The L1 source might rug us with a reorg between API calls, catch that.
 		if ontoL1 != currentL1 {
 			err = fmt.Errorf("the L1 source reorged, the block for N+1 %s doesn't have the previously fetched block N %s as parent, but builds on %s instead", nextRefL1, currentL1, ontoL1)

--- a/opnode/rollup/types.go
+++ b/opnode/rollup/types.go
@@ -1,8 +1,48 @@
 package rollup
 
-import "github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
 
 type Genesis struct {
+	// The L1 block that the rollup starts *after* (no derived transactions)
 	L1 eth.BlockID
+	// The L2 block the rollup starts from (no transactions, pre-configured state)
 	L2 eth.BlockID
+	// Timestamp of L2 block
+	L2Time uint64
 }
+
+type Config struct {
+	// Genesis anchor point of the rollup
+	Genesis Genesis
+	// Seconds per L2 block
+	BlockTime uint64
+	// Sequencer batches may not be more than MaxSequencerTimeDiff seconds after
+	// the L1 timestamp of the sequencing window end.
+	//
+	// Note: When L1 has many 1 second consecutive blocks, and L2 grows at fixed 2 seconds,
+	// the L2 time may still grow beyond this difference.
+	MaxSequencerTimeDiff uint64
+	// Number of epochs (L1 blocks) per sequencing window
+	SeqWindowSize uint64
+	// Required to verify L1 signatures
+	L1ChainID *big.Int
+
+	// L2 address receiving all L2 transaction fees
+	FeeRecipientAddress common.Address
+	// L1 address that batches are sent to
+	BatchInboxAddress common.Address
+	// Acceptable batch-sender address
+	BatchSenderAddress common.Address
+}
+
+func (c *Config) L1Signer() types.Signer {
+	return types.NewLondonSigner(c.L1ChainID)
+}
+
+type Epoch uint64


### PR DESCRIPTION
This updates the block-derivation to:
- Take a sequencing window as input
- Check the size and consistency of the input
- Derive L2 payloads from possibly out-of-order batches (ignore past/future epochs with overlapping sequencing window)
- Build L2 blocks with fixed block time (fill gaps with empty blocks)
- Limit L2 sequencer-produced blocks to a time-window, do not fill ridiculous out-of-window gaps with empty L2 blocks (by accident or not)
- Force deposits of the epoch (first L1 block of window) into the batch of the first L2 time slot (created if none exists)

This is a *work in progress*. this is output from discussion with Karl/Norswap about the many options.

Fixes #185
Work in progress #183

TODOs (may split into more PRs):
- Spec for sequencing window, and outline why this seems to work best.
- Load new rollup configuration (block time and special addresses etc.)
- Update L1 downloader to fetch receipts lazily, and cache the block data (repeated usage due to overlapping sequencing windows).
- Implement batch encoding/parsing
