### PR TITLE
ref impl: Remove combined l1 sources

### DIFF
--- a/opnode/cmd/main.go
+++ b/opnode/cmd/main.go
@@ -115,7 +115,7 @@ func NewConfig(ctx *cli.Context) (*node.Config, error) {
 	}
 	cfg := &node.Config{
 		/* Required Flags */
-		L1NodeAddrs:   ctx.GlobalStringSlice(L1NodeAddrs.Name),
+		L1NodeAddr:    ctx.GlobalString(L1NodeAddr.Name),
 		L2EngineAddrs: ctx.GlobalStringSlice(L2EngineAddrs.Name),
 		L2Hash:        L2Hash,
 		L1Hash:        L1Hash,
@@ -151,7 +151,7 @@ func NewLogConfig(ctx *cli.Context) (node.LogConfig, error) {
 // }
 
 var Flags = []cli.Flag{
-	L1NodeAddrs,
+	L1NodeAddr,
 	L2EngineAddrs,
 	GenesisL2Hash,
 	GenesisL1Hash,
@@ -163,10 +163,11 @@ var Flags = []cli.Flag{
 
 var (
 	/* Required Flags */
-	L1NodeAddrs = cli.StringSliceFlag{
+	L1NodeAddr = cli.StringFlag{
 		Name:     "l1",
-		Usage:    "Addresses of L1 User JSON-RPC endpoints to use (eth namespace required)",
+		Usage:    "Address of L1 User JSON-RPC endpoint to use (eth namespace required)",
 		Required: true,
+		Value:    "http://127.0.0.1:8545",
 	}
 	L2EngineAddrs = cli.StringSliceFlag{
 		Name:     "l2",

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -117,7 +117,7 @@ func TestSystemE2E(t *testing.T) {
 		L2Hash:        l2GenesisHash,
 		L1Hash:        l1GenesisHash,
 		L1Num:         0,
-		L1NodeAddrs:   []string{endpoint(cfg.l1.nodeConfig)},
+		L1NodeAddr:    endpoint(cfg.l1.nodeConfig),
 		L2EngineAddrs: []string{endpoint(cfg.l2.nodeConfig)},
 	}
 	node, err := rollupNode.New(context.Background(), nodeCfg, testlog.Logger(t, log.LvlTrace))


### PR DESCRIPTION
**Description**

L1 Sources are not guaranteed to synchronized with one another and
the rollup node code is not built to re-synchronized the underlying
nodes.

**End User Changes**
The `--l1` option is now only accepts one address rather than being a string slice.
With urfave do see this comment on the string slice flag: https://github.com/urfave/cli/issues/910

