### PR TITLE
ref impl: Track code coverage across packages

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -26,6 +26,6 @@ jobs:
           # rules: https://golangci-lint.run/usage/quick-start/
           args: -E asciicheck,goimports
       - name: Test and generate coverage
-        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+        run: go test -coverpkg=all -coverprofile=coverage.out -covermode=atomic ./...
       - name: Upload coverage output
         uses: codecov/codecov-action@v2

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -26,6 +26,6 @@ jobs:
           # rules: https://golangci-lint.run/usage/quick-start/
           args: -E asciicheck,goimports
       - name: Test and generate coverage
-        run: go test -coverpkg=all -coverprofile=coverage.out -covermode=atomic ./...
+        run: go test -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...
       - name: Upload coverage output
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
**Description**

This enables tracking code coverage across packages to see an increase
in code coverage due to the e2e test.


**Metadata**
- Fixes #135 
