### PR TITLE
ref impl: Sync algorithm for sequencing

### DIFF
--- a/opnode/eth/id.go
+++ b/opnode/eth/id.go
@@ -20,3 +20,34 @@ func (id BlockID) String() string {
 func (id BlockID) TerminalString() string {
 	return fmt.Sprintf("%s:%d", id.Hash.TerminalString(), id.Number)
 }
+
+type L2Node struct {
+	Self     BlockID
+	L2Parent BlockID
+	L1Parent BlockID
+}
+
+func (id L2Node) String() string {
+	return fmt.Sprintf("%s:%d", id.Self.Hash.String(), id.Self.Number)
+}
+
+// TerminalString implements log.TerminalStringer, formatting a string for console
+// output during logging.
+func (id L2Node) TerminalString() string {
+	return fmt.Sprintf("%s:%d", id.Self.Hash.TerminalString(), id.Self.Number)
+}
+
+type L1Node struct {
+	Self   BlockID
+	Parent BlockID
+}
+
+func (id L1Node) String() string {
+	return fmt.Sprintf("%s:%d", id.Self.Hash.String(), id.Self.Number)
+}
+
+// TerminalString implements log.TerminalStringer, formatting a string for console
+// output during logging.
+func (id L1Node) TerminalString() string {
+	return fmt.Sprintf("%s:%d", id.Self.Hash.TerminalString(), id.Self.Number)
+}

--- a/opnode/l1/source.go
+++ b/opnode/l1/source.go
@@ -77,7 +77,8 @@ func (s Source) Close() {
 }
 
 func (s Source) FetchL1Info(ctx context.Context, id eth.BlockID) (derive.L1Info, error) {
-	return nil, nil
+	block, _, err := s.Fetch(ctx, id)
+	return block, err
 }
 func (s Source) FetchReceipts(ctx context.Context, id eth.BlockID) ([]*types.Receipt, error) {
 	_, receipts, err := s.Fetch(ctx, id)

--- a/opnode/l1/source.go
+++ b/opnode/l1/source.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup/derive"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -87,4 +88,18 @@ func (s Source) AddReceiptWorkers(n int) int {
 func (s Source) Close() {
 	s.client.Close()
 	s.downloader.Close()
+}
+
+func (s Source) FetchL1Info(ctx context.Context, id eth.BlockID) (derive.L1Info, error) {
+	return nil, nil
+}
+func (s Source) FetchReceipts(ctx context.Context, id eth.BlockID) ([]*types.Receipt, error) {
+	_, receipts, err := s.Fetch(ctx, id)
+	return receipts, err
+}
+func (s Source) FetchBatches(ctx context.Context, window []eth.BlockID) ([]derive.BatchData, error) {
+	return nil, nil
+}
+func (s Source) FetchL2Info(ctx context.Context, id eth.BlockID) (derive.L2Info, error) {
+	return nil, nil
 }

--- a/opnode/l1/source.go
+++ b/opnode/l1/source.go
@@ -39,20 +39,6 @@ func (s Source) BlockLinkByNumber(ctx context.Context, num uint64) (self eth.Blo
 
 }
 
-func (s Source) HeadBlockLink(ctx context.Context) (self eth.BlockID, parent eth.BlockID, err error) {
-	header, err := s.client.HeaderByNumber(ctx, nil)
-	if err != nil {
-		// w%: wrap the error, we still need to detect if a canonical block is not found, a.k.a. end of chain.
-		return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("failed to determine block-hash of head block, could not get header: %w", err)
-	}
-	parentNum := header.Number.Uint64()
-	if parentNum > 0 {
-		parentNum -= 1
-	}
-	return eth.BlockID{Hash: header.Hash(), Number: header.Number.Uint64()}, eth.BlockID{Hash: header.ParentHash, Number: parentNum}, nil
-
-}
-
 func (s Source) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
 	return s.client.SubscribeNewHead(ctx, ch)
 }

--- a/opnode/l1/source.go
+++ b/opnode/l1/source.go
@@ -38,6 +38,20 @@ func (s Source) BlockLinkByNumber(ctx context.Context, num uint64) (self eth.Blo
 
 }
 
+func (s Source) HeadBlockLink(ctx context.Context) (self eth.BlockID, parent eth.BlockID, err error) {
+	header, err := s.client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		// w%: wrap the error, we still need to detect if a canonical block is not found, a.k.a. end of chain.
+		return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("failed to determine block-hash of head block, could not get header: %w", err)
+	}
+	parentNum := header.Number.Uint64()
+	if parentNum > 0 {
+		parentNum -= 1
+	}
+	return eth.BlockID{Hash: header.Hash(), Number: header.Number.Uint64()}, eth.BlockID{Hash: header.ParentHash, Number: parentNum}, nil
+
+}
+
 func (s Source) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
 	return s.client.SubscribeNewHead(ctx, ch)
 }

--- a/opnode/rollup/derive/doc.go
+++ b/opnode/rollup/derive/doc.go
@@ -14,3 +14,7 @@
 //
 // The steps should be keep separate to enable easier testing.
 package derive
+
+// Mock interfaces. TODO: Remove
+type BatchData interface{}
+type L2Info interface{}

--- a/opnode/rollup/derive/invert.go
+++ b/opnode/rollup/derive/invert.go
@@ -35,7 +35,7 @@ type Block interface {
 	Transactions() types.Transactions
 }
 
-// BlockReferences takes a L2 block and determines which L1 block it was derived from, and the L2 self and parent id.
+// BlockReferences takes a L2 block and determines which L1 block it was derived from, its L2 parent id, and its own id.
 func BlockReferences(l2Block Block, genesis *rollup.Genesis) (eth.L2Node, error) {
 	self := eth.BlockID{Hash: l2Block.Hash(), Number: l2Block.NumberU64()}
 	if self.Number <= genesis.L2.Number {

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -130,7 +130,12 @@ func (e *Driver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL
 }
 
 func (e *Driver) findSyncStart(ctx context.Context) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error) {
-	return rollupSync.FindSyncStart(ctx, e.chainSource, &e.genesis)
+	var l1s []eth.BlockID
+	l1s, refL2, err = rollupSync.FindSyncStart(ctx, e.chainSource, &e.genesis)
+	if err != nil && len(l1s) > 0 {
+		nextRefL1 = l1s[0]
+	}
+	return
 }
 
 func (e *Driver) driverStep(ctx context.Context, nextRefL1 eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error) {

--- a/opnode/rollup/sync/reference.go
+++ b/opnode/rollup/sync/reference.go
@@ -13,6 +13,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+// Sync Source Interface TODOs:
+// Relax block by hash???  would have to use by number interface though
+// Merge v1 and v2
+// Put node definitions in eth?
+
 // SyncSource implements SyncReference with a L2 block sources and L1 hash-by-number source
 type SyncSource struct {
 	L1 interface {
@@ -70,4 +75,60 @@ type SyncReference interface {
 
 	// RefByL2Hash fetches the L1 and L2 block IDs from the engine for the given L2 block hash.
 	RefByL2Hash(ctx context.Context, l2Hash common.Hash, genesis *rollup.Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error)
+}
+
+// SyncReferenceV2 wraps the return types of SyncReference to be easier to work with.
+type SyncReferenceV2 interface {
+	L1NodeByNumber(ctx context.Context, l1Num uint64) (L1Node, error)
+	L1HeadNode(ctx context.Context) (L1Node, error)
+	L2NodeByNumber(ctx context.Context, l2Num *big.Int, genesis *rollup.Genesis) (L2Node, error)
+	L2NodeByHash(ctx context.Context, l2Hash common.Hash, genesis *rollup.Genesis) (L2Node, error)
+}
+
+type SyncSourceV2 struct {
+	SyncReference
+}
+
+func (src SyncSourceV2) L1NodeByNumber(ctx context.Context, l1Num uint64) (L1Node, error) {
+	self, parent, err := src.RefByL1Num(ctx, l1Num)
+	if err != nil {
+		return L1Node{}, err
+	}
+	return L1Node{self: self, parent: parent}, nil
+
+}
+
+func (src SyncSourceV2) L1HeadNode(ctx context.Context) (L1Node, error) {
+	self, parent, err := src.L1HeadRef(ctx)
+	if err != nil {
+		return L1Node{}, err
+	}
+	return L1Node{self: self, parent: parent}, nil
+}
+
+func (src SyncSourceV2) L2NodeByNumber(ctx context.Context, l2Num *big.Int, genesis *rollup.Genesis) (L2Node, error) {
+	l1Ref, l2ref, l2ParentHash, err := src.RefByL2Num(ctx, l2Num, genesis)
+	if err != nil {
+		return L2Node{}, err
+	}
+	return L2Node{self: l2ref, l1parent: l1Ref, l2parent: eth.BlockID{Hash: l2ParentHash, Number: l2ref.Number - 1}}, nil
+}
+
+func (src SyncSourceV2) L2NodeByHash(ctx context.Context, l2Hash common.Hash, genesis *rollup.Genesis) (L2Node, error) {
+	l1Ref, l2ref, l2ParentHash, err := src.RefByL2Hash(ctx, l2Hash, genesis)
+	if err != nil {
+		return L2Node{}, err
+	}
+	return L2Node{self: l2ref, l1parent: l1Ref, l2parent: eth.BlockID{Hash: l2ParentHash, Number: l2ref.Number - 1}}, nil
+}
+
+type L2Node struct {
+	self     eth.BlockID
+	l2parent eth.BlockID
+	l1parent eth.BlockID
+}
+
+type L1Node struct {
+	self   eth.BlockID
+	parent eth.BlockID
 }

--- a/opnode/rollup/sync/reference.go
+++ b/opnode/rollup/sync/reference.go
@@ -16,6 +16,7 @@ import (
 // SyncSource implements SyncReference with a L2 block sources and L1 hash-by-number source
 type SyncSource struct {
 	L1 interface {
+		HeadBlockLink(ctx context.Context) (self eth.BlockID, parent eth.BlockID, err error)
 		BlockLinkByNumber(ctx context.Context, num uint64) (self eth.BlockID, parent eth.BlockID, err error)
 	}
 	L2 interface {
@@ -27,6 +28,11 @@ type SyncSource struct {
 // RefByL1Num fetches the canonical L1 block hash and the parent for the given L1 block height.
 func (src SyncSource) RefByL1Num(ctx context.Context, l1Num uint64) (self eth.BlockID, parent eth.BlockID, err error) {
 	return src.L1.BlockLinkByNumber(ctx, l1Num)
+}
+
+// L1HeadRef fetches the canonical L1 block hash and the parent for the head of the L1 chain.
+func (src SyncSource) L1HeadRef(ctx context.Context) (self eth.BlockID, parent eth.BlockID, err error) {
+	return src.L1.HeadBlockLink(ctx)
 }
 
 // RefByL2Num fetches the L1 and L2 block IDs from the engine for the given L2 block height.
@@ -54,6 +60,9 @@ func (src SyncSource) RefByL2Hash(ctx context.Context, l2Hash common.Hash, genes
 type SyncReference interface {
 	// RefByL1Num fetches the canonical L1 block hash and the parent for the given L1 block height.
 	RefByL1Num(ctx context.Context, l1Num uint64) (self eth.BlockID, parent eth.BlockID, err error)
+
+	// L1HeadRef fetches the canonical L1 block hash and the parent for the head of the L1 chain.
+	L1HeadRef(ctx context.Context) (self eth.BlockID, parent eth.BlockID, err error)
 
 	// RefByL2Num fetches the L1 and L2 block IDs from the engine for the given L2 block height.
 	// Use a nil height to fetch the head.

--- a/opnode/rollup/sync/reference.go
+++ b/opnode/rollup/sync/reference.go
@@ -79,56 +79,45 @@ type SyncReference interface {
 
 // SyncReferenceV2 wraps the return types of SyncReference to be easier to work with.
 type SyncReferenceV2 interface {
-	L1NodeByNumber(ctx context.Context, l1Num uint64) (L1Node, error)
-	L1HeadNode(ctx context.Context) (L1Node, error)
-	L2NodeByNumber(ctx context.Context, l2Num *big.Int, genesis *rollup.Genesis) (L2Node, error)
-	L2NodeByHash(ctx context.Context, l2Hash common.Hash, genesis *rollup.Genesis) (L2Node, error)
+	L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1Node, error)
+	L1HeadNode(ctx context.Context) (eth.L1Node, error)
+	L2NodeByNumber(ctx context.Context, l2Num *big.Int, genesis *rollup.Genesis) (eth.L2Node, error)
+	L2NodeByHash(ctx context.Context, l2Hash common.Hash, genesis *rollup.Genesis) (eth.L2Node, error)
 }
 
 type SyncSourceV2 struct {
 	SyncReference
 }
 
-func (src SyncSourceV2) L1NodeByNumber(ctx context.Context, l1Num uint64) (L1Node, error) {
+func (src SyncSourceV2) L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1Node, error) {
 	self, parent, err := src.RefByL1Num(ctx, l1Num)
 	if err != nil {
-		return L1Node{}, err
+		return eth.L1Node{}, err
 	}
-	return L1Node{self: self, parent: parent}, nil
+	return eth.L1Node{Self: self, Parent: parent}, nil
 
 }
 
-func (src SyncSourceV2) L1HeadNode(ctx context.Context) (L1Node, error) {
+func (src SyncSourceV2) L1HeadNode(ctx context.Context) (eth.L1Node, error) {
 	self, parent, err := src.L1HeadRef(ctx)
 	if err != nil {
-		return L1Node{}, err
+		return eth.L1Node{}, err
 	}
-	return L1Node{self: self, parent: parent}, nil
+	return eth.L1Node{Self: self, Parent: parent}, nil
 }
 
-func (src SyncSourceV2) L2NodeByNumber(ctx context.Context, l2Num *big.Int, genesis *rollup.Genesis) (L2Node, error) {
+func (src SyncSourceV2) L2NodeByNumber(ctx context.Context, l2Num *big.Int, genesis *rollup.Genesis) (eth.L2Node, error) {
 	l1Ref, l2ref, l2ParentHash, err := src.RefByL2Num(ctx, l2Num, genesis)
 	if err != nil {
-		return L2Node{}, err
+		return eth.L2Node{}, err
 	}
-	return L2Node{self: l2ref, l1parent: l1Ref, l2parent: eth.BlockID{Hash: l2ParentHash, Number: l2ref.Number - 1}}, nil
+	return eth.L2Node{Self: l2ref, L1Parent: l1Ref, L2Parent: eth.BlockID{Hash: l2ParentHash, Number: l2ref.Number - 1}}, nil
 }
 
-func (src SyncSourceV2) L2NodeByHash(ctx context.Context, l2Hash common.Hash, genesis *rollup.Genesis) (L2Node, error) {
+func (src SyncSourceV2) L2NodeByHash(ctx context.Context, l2Hash common.Hash, genesis *rollup.Genesis) (eth.L2Node, error) {
 	l1Ref, l2ref, l2ParentHash, err := src.RefByL2Hash(ctx, l2Hash, genesis)
 	if err != nil {
-		return L2Node{}, err
+		return eth.L2Node{}, err
 	}
-	return L2Node{self: l2ref, l1parent: l1Ref, l2parent: eth.BlockID{Hash: l2ParentHash, Number: l2ref.Number - 1}}, nil
-}
-
-type L2Node struct {
-	self     eth.BlockID
-	l2parent eth.BlockID
-	l1parent eth.BlockID
-}
-
-type L1Node struct {
-	self   eth.BlockID
-	parent eth.BlockID
+	return eth.L2Node{Self: l2ref, L1Parent: l1Ref, L2Parent: eth.BlockID{Hash: l2ParentHash, Number: l2ref.Number - 1}}, nil
 }

--- a/opnode/rollup/sync/start.go
+++ b/opnode/rollup/sync/start.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 var WrongChainErr = errors.New("wrong chain")
@@ -141,94 +140,9 @@ func findL1Range(ctx context.Context, source SyncReferenceV2, begin eth.BlockID)
 // FindSyncStart finds nextL1s: the L1 blocks needed next for sync, to derive into a L2 block on top of refL2.
 // If the L1 reorgs then this will find the common history to build on top of and then follow the first step of the reorg.
 func FindSyncStart(ctx context.Context, reference SyncReference, genesis *rollup.Genesis) (nextRefL1, refL2 eth.BlockID, err error) {
-	var refL1 eth.BlockID    // the L1 block the refL2 was derived from
-	var parentL2 common.Hash // the parent of refL2
-	// Start at L2 head
-	refL1, refL2, parentL2, err = reference.RefByL2Num(ctx, nil, genesis)
-	if err != nil {
-		err = fmt.Errorf("failed to fetch L2 head: %v", err)
-		return
+	l1s, refL2, err := V3FindSyncStart(ctx, SyncSourceV2{reference}, genesis)
+	if err != nil && len(l1s) > 0 {
+		nextRefL1 = l1s[0]
 	}
-	// Check if L1 source has the block
-	var currentL1 eth.BlockID // the expected L1 block at the height of refL1
-	currentL1, _, err = reference.RefByL1Num(ctx, refL1.Number)
-	if err != nil {
-		if !errors.Is(err, ethereum.NotFound) {
-			err = fmt.Errorf("failed to lookup block %d in L1: %w", refL1.Number, err)
-			return
-		}
-		// If the L1 did not find the block, it might be out of sync.
-		// We cannot sync from L1 in this case, but we still traverse back to
-		// make sure we are not just in a reorg to a L1 chain with fewer blocks.
-		err = nil
-		currentL1 = eth.BlockID{} // empty = not found
-	}
-	if currentL1 == refL1 {
-		// L1 node has head-block of execution-engine, so we should fetch the L1 block that builds on top.
-		var ontoL1 eth.BlockID // ontoL1 is the parent, to make sure we got a nextRefL1 that connects as expected.
-		nextRefL1, ontoL1, err = reference.RefByL1Num(ctx, refL1.Number+1)
-		if err != nil {
-			// If refL1 is the head block, then we might not have a next block to build on the head
-			if errors.Is(err, ethereum.NotFound) {
-				// return the same as the engine head was already built on, no error.
-				nextRefL1 = refL1
-				refL2 = eth.BlockID{Hash: parentL2, Number: refL2.Number}
-				if refL2.Number > 0 {
-					refL2.Number -= 1
-				}
-				err = nil
-				return
-			}
-			return
-		}
-		// The L1 source might rug us with a reorg between API calls, catch that.
-		if ontoL1 != currentL1 {
-			err = fmt.Errorf("the L1 source reorged, the block for N+1 %s doesn't have the previously fetched block N %s as parent, but builds on %s instead", nextRefL1, currentL1, ontoL1)
-		}
-		return
-	}
-
-	// Search back: linear walk back from engine head. Should only be as deep as the reorg.
-	for refL2.Number > 0 {
-		// remember the canonical L1 block that builds on top of the L1 source block of the L2 parent block.
-		nextRefL1 = currentL1
-		refL1, refL2, parentL2, err = reference.RefByL2Hash(ctx, parentL2, genesis)
-		if err != nil {
-			// TODO: re-attempt look-up, now that we already traversed previous history?
-			err = fmt.Errorf("failed to lookup block %s in L2: %w", refL2, err) // refL2 is previous parentL2
-			return
-		}
-		// Check if L1 source has the block that derived the L2 block we are planning to build on
-		currentL1, _, err = reference.RefByL1Num(ctx, refL1.Number)
-		if err != nil {
-			if !errors.Is(err, ethereum.NotFound) {
-				err = fmt.Errorf("failed to lookup block %d in L1: %w", refL1.Number, err)
-				return
-			}
-			// again, if L1 does not have the block, then we just search if we are reorging.
-			err = nil
-			currentL1 = eth.BlockID{} // empty = not found
-		}
-		if currentL1 == refL1 {
-			// check if we had a L1 block to build on top of the common chain with
-			if nextRefL1 == (eth.BlockID{}) {
-				err = ethereum.NotFound
-			}
-			return
-		}
-		// TODO: after e.g. initial N steps, use binary search instead
-		// (relies on block numbers, not great for tip of chain, but nice-to-have in deep reorgs)
-	}
-	// Enforce that we build on the desired genesis block.
-	// The engine might be configured for a different chain or older testnet.
-	if refL2 != genesis.L2 {
-		err = fmt.Errorf("unexpected L2 genesis block: %s, expected %s, %w", refL2, genesis.L2, WrongChainErr)
-		return
-	}
-	if currentL1 != genesis.L1 {
-		err = fmt.Errorf("unexpected L1 anchor block: %s, expected %s, %w", currentL1, genesis.L1, WrongChainErr)
-		return
-	}
-	// we got the correct genesis, all good, but a lot to sync!
 	return
 }

--- a/opnode/rollup/sync/start.go
+++ b/opnode/rollup/sync/start.go
@@ -14,7 +14,131 @@ import (
 
 var WrongChainErr = errors.New("wrong chain")
 
-// FindSyncStart finds nextRefL1: the L1 block needed next for sync, to derive into a L2 block on top of refL2.
+// The ethereum chain is a DAG of blocks with the root block being the genesis block.
+// At any given time, the head (or tip) of the chain can change if an offshoot of the chain
+// has a higher difficulty. This is known as a re-organization of the canonical chain.
+// Each block points to a parent block and the node is responsible for deciding which block is the head
+// and thus the mapping from block number to canonical block.
+//
+// The optimism chain has similar properties, but also retains references to the ethereum chain.
+// Each optimism block retains a reference to an ethereum (L1) block and to it's parent optimism (L2) block.
+// The L2 chain node must satisfy the following validity rules
+//     1. l2block.height == l2parent.block.height + 1
+//     2. l2block.l1parent.height >= l2block.l2parent.l1parent.height
+//     3. l2block.l1parent is in the canonical chain on L1
+//     4. l1_rollup_genesis is reachable from l2block.l1parent
+//
+//
+// During normal operation, both the L1 and L2 canonical chains can change.
+//     - L1 reorg
+//     - L1 extension
+//     - L2 reorg
+//     - L2 extension
+//
+// When one of those actions occurs, the L2 chain head may need to be updated and we would like a portion of the L1 chain
+// that we should use to derive the L2 chain from.
+// These are two different functions, but doing the first requires walking both chains in which case it is easy to also
+// return a portion of the chain.
+//
+// This function returns the highest possible l2block that is valid. This is the (possibly new) L2 chain head.
+// It also returns a portion of the L1 chain starting just after l2block.l1parent.number.
+//     - The L1 chain was canonical when the function was called.
+//     - The L1 chain is continuous
+//     - The L1 chain is from low to high
+//     - The length is not defined.
+// If err is not nil, the above return values are not well defined. An error will be returned in the following cases:
+//     - Wrapped ethereum.NotFound if it could not find a block in L1 or L2. This error may be temporary.
+//     - Wrapped WrongChainErr if the l1_rollup_genesis block is not reachable from the L2 chain.
+//     - ??
+
+func V3FindSyncStart(ctx context.Context, source SyncReferenceV2, genesis *rollup.Genesis) ([]eth.BlockID, eth.BlockID, error) {
+	l2Head, err := findL2Head(ctx, source, genesis)
+	if err != nil {
+		return nil, eth.BlockID{}, err
+	}
+	l1blocks, err := findL1Range(ctx, source, l2Head.l1parent)
+	if err != nil {
+		return nil, eth.BlockID{}, fmt.Errorf("failed to fetch l1 range: %w", err)
+	}
+
+	return l1blocks, l2Head.self, nil
+
+}
+
+// findL2Head takes the current L2 Head and then finds the topmost L2 head that is valid
+// In the case that there are no re-orgs,
+func findL2Head(ctx context.Context, source SyncReferenceV2, genesis *rollup.Genesis) (L2Node, error) {
+	// Starting point
+	l2Head, err := source.L2NodeByNumber(ctx, nil, genesis)
+	if err != nil {
+		return L2Node{}, fmt.Errorf("failed to fetch L2 head: %w", err)
+	}
+	// Walk L2 chain from L2 head to first L2 block which has a L1 Parent that is canonical. May walk to L2 genesis
+	for n := l2Head; ; {
+		l1header, err := source.L1NodeByNumber(ctx, n.l1parent.Number)
+		if err != nil {
+			// Generic error, bail out.
+			if !errors.Is(err, ethereum.NotFound) {
+				return L2Node{}, fmt.Errorf("failed to fetch L1 block %v: %w", n.l1parent.Number, err)
+			}
+			// L1 block not found, keep walking chain
+		} else {
+			// L1 Block found, check if matches & should keep walking the chain
+			if l1header.self.Hash == n.l1parent.Hash {
+				return n, nil
+			}
+		}
+
+		// Don't walk past genesis. If we were at the L2 genesis, but could not find the L1 genesis
+		// pointed to from it, we are on the wrong L1 chain.
+		if n.self.Hash == genesis.L2.Hash || n.self.Number == genesis.L2.Number {
+			return L2Node{}, WrongChainErr
+		}
+
+		// Pull L2 parent for next iteration
+		n, err = source.L2NodeByHash(ctx, n.l2parent.Hash, genesis)
+		if err != nil {
+			return L2Node{}, fmt.Errorf("failed to fetch L2 block by hash %v: %w", n.l2parent.Hash, err)
+		}
+	}
+}
+
+func findL1Range(ctx context.Context, source SyncReferenceV2, begin eth.BlockID) ([]eth.BlockID, error) {
+	if _, err := source.L1NodeByNumber(ctx, begin.Number); err != nil {
+		return nil, fmt.Errorf("failed to fetch L1 block %v %v: %w", begin.Number, begin.Hash, err)
+	}
+	// TODO: Check hash here (even if slightly redudant)
+	l1head, err := source.L1HeadNode(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch head L1 block: %w", err)
+	}
+	maxBlocks := uint64(100)
+	if l1head.self.Number-begin.Number <= maxBlocks {
+		fmt.Println("Capping max blocks")
+		maxBlocks = l1head.self.Number - begin.Number
+		fmt.Println(maxBlocks)
+	}
+
+	prevHash := begin.Hash
+	var res []eth.BlockID
+	for i := begin.Number + 1; i < begin.Number+maxBlocks+1; i++ {
+		fmt.Println(i, i)
+		n, err := source.L1NodeByNumber(ctx, i)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch L1 block %v: %w", i, err)
+		}
+		fmt.Println(prevHash, n.parent.Hash)
+		if n.parent.Hash != prevHash {
+			return nil, errors.New("re-organization occurred while attempting to get l1 range")
+		}
+		prevHash = n.self.Hash
+		res = append(res, n.self)
+	}
+
+	return res, nil
+}
+
+// FindSyncStart finds nextL1s: the L1 blocks needed next for sync, to derive into a L2 block on top of refL2.
 // If the L1 reorgs then this will find the common history to build on top of and then follow the first step of the reorg.
 func FindSyncStart(ctx context.Context, reference SyncReference, genesis *rollup.Genesis) (nextRefL1, refL2 eth.BlockID, err error) {
 	var refL1 eth.BlockID    // the L1 block the refL2 was derived from

--- a/opnode/rollup/sync/start.go
+++ b/opnode/rollup/sync/start.go
@@ -127,7 +127,8 @@ func FindL1Range(ctx context.Context, source SyncReferenceV2, begin eth.BlockID)
 			return nil, fmt.Errorf("failed to fetch L1 block %v: %w", i, err)
 		}
 		fmt.Println(prevHash, n.parent.Hash)
-		if n.parent.Hash != prevHash {
+		// TODO(Joshua): Look into why this fails around the genesis block
+		if n.parent.Number != 0 && n.parent.Hash != prevHash {
 			return nil, errors.New("re-organization occurred while attempting to get l1 range")
 		}
 		prevHash = n.self.Hash

--- a/opnode/rollup/sync/start.go
+++ b/opnode/rollup/sync/start.go
@@ -8,7 +8,7 @@
 // and thus the mapping from block number to canonical block.
 //
 // The optimism chain has similar properties, but also retains references to the ethereum chain.
-// Each optimism block retains a reference to an ethereum (L1) block and to it's parent optimism (L2) block.
+// Each optimism block retains a reference to an L1 block and to its parent L2 block.
 // The L2 chain node must satisfy the following validity rules
 //     1. l2block.height == l2parent.block.height + 1
 //     2. l2block.l1parent.height >= l2block.l2parent.l1parent.height
@@ -16,7 +16,8 @@
 //     4. l1_rollup_genesis is reachable from l2block.l1parent
 //
 //
-// During normal operation, both the L1 and L2 canonical chains can change.
+// During normal operation, both the L1 and L2 canonical chains can change, due to a reorg
+// or an extension (new block).
 //     - L1 reorg
 //     - L1 extension
 //     - L2 reorg

--- a/opnode/rollup/sync/start.go
+++ b/opnode/rollup/sync/start.go
@@ -51,11 +51,11 @@ var WrongChainErr = errors.New("wrong chain")
 //     - ??
 
 func V3FindSyncStart(ctx context.Context, source SyncReferenceV2, genesis *rollup.Genesis) ([]eth.BlockID, eth.BlockID, error) {
-	l2Head, err := findL2Head(ctx, source, genesis)
+	l2Head, err := FindL2Head(ctx, source, genesis)
 	if err != nil {
 		return nil, eth.BlockID{}, err
 	}
-	l1blocks, err := findL1Range(ctx, source, l2Head.l1parent)
+	l1blocks, err := FindL1Range(ctx, source, l2Head.l1parent)
 	if err != nil {
 		return nil, eth.BlockID{}, fmt.Errorf("failed to fetch l1 range: %w", err)
 	}
@@ -66,7 +66,7 @@ func V3FindSyncStart(ctx context.Context, source SyncReferenceV2, genesis *rollu
 
 // findL2Head takes the current L2 Head and then finds the topmost L2 head that is valid
 // In the case that there are no re-orgs,
-func findL2Head(ctx context.Context, source SyncReferenceV2, genesis *rollup.Genesis) (L2Node, error) {
+func FindL2Head(ctx context.Context, source SyncReferenceV2, genesis *rollup.Genesis) (L2Node, error) {
 	// Starting point
 	l2Head, err := source.L2NodeByNumber(ctx, nil, genesis)
 	if err != nil {
@@ -102,7 +102,7 @@ func findL2Head(ctx context.Context, source SyncReferenceV2, genesis *rollup.Gen
 	}
 }
 
-func findL1Range(ctx context.Context, source SyncReferenceV2, begin eth.BlockID) ([]eth.BlockID, error) {
+func FindL1Range(ctx context.Context, source SyncReferenceV2, begin eth.BlockID) ([]eth.BlockID, error) {
 	if _, err := source.L1NodeByNumber(ctx, begin.Number); err != nil {
 		return nil, fmt.Errorf("failed to fetch L1 block %v %v: %w", begin.Number, begin.Hash, err)
 	}

--- a/opnode/rollup/sync/start_test.go
+++ b/opnode/rollup/sync/start_test.go
@@ -130,7 +130,7 @@ func (c *syncStartTestCase) Run(t *testing.T) {
 		L2: fakeID(c.GenesisL2, 0),
 	}
 
-	nextRefL1s, refL2, err := V3FindSyncStart(context.Background(), msr, genesis)
+	nextRefL1s, refL2, err := FindSyncStart(context.Background(), msr, genesis)
 
 	if c.ExpectedErr != nil {
 		assert.Error(t, err, "Expecting an error in this test case")

--- a/opnode/rollup/sync/start_test.go
+++ b/opnode/rollup/sync/start_test.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -130,10 +129,6 @@ func (c *syncStartTestCase) Run(t *testing.T) {
 		L1: fakeID(c.GenesisL1, c.OffsetL2),
 		L2: fakeID(c.GenesisL2, 0),
 	}
-
-	fmt.Println(engL1)
-	fmt.Println(actL1)
-	fmt.Println(engL2)
 
 	nextRefL1s, refL2, err := V3FindSyncStart(context.Background(), msr, genesis)
 

--- a/opnode/rollup/sync/start_test.go
+++ b/opnode/rollup/sync/start_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -103,17 +104,21 @@ type syncStartTestCase struct {
 	Name string
 
 	OffsetL2 uint64
-	EngineL1 string
-	EngineL2 string
-	ActualL1 string
+	EngineL1 string // L1 Chain prior to a re-org or other change
+	EngineL2 string // L2 Chain that follows from L1Chain
+	ActualL1 string // L1 Chain after a change may have occurred
 
 	GenesisL1 rune
 	GenesisL2 rune
 
-	ExpectedNextRefL1 rune
-	ExpectedRefL2     rune
+	ExpectedNextRefsL1 string // The L1 extension to follow (i.e. L1 after the L1 parent in the new L2 Head)
+	ExpectedRefL2      rune   // The new L2 tip after a L1 change that may have occured
 
 	ExpectedErr error
+}
+
+func refToRune(r eth.BlockID) rune {
+	return rune(r.Hash.Bytes()[0])
 }
 
 func (c *syncStartTestCase) Run(t *testing.T) {
@@ -131,196 +136,185 @@ func (c *syncStartTestCase) Run(t *testing.T) {
 		L2: mockID(c.GenesisL2, 0),
 	}
 
-	expectedNextRefL1Num := ^uint64(0)
-	for i, id := range c.ActualL1 {
-		if id == c.ExpectedNextRefL1 {
-			expectedNextRefL1Num = uint64(i)
-		}
-	}
-	if c.ExpectedNextRefL1 == 0 {
-		expectedNextRefL1Num = uint64(0)
-	}
-	expectedNextRefL1 := mockID(c.ExpectedNextRefL1, expectedNextRefL1Num)
+	fmt.Println(engL1)
+	fmt.Println(actL1)
+	fmt.Println(engL2)
 
-	expectedRefL2Num := ^uint64(0)
-	for i, id := range c.EngineL2 {
-		if id == c.ExpectedRefL2 {
-			expectedRefL2Num = uint64(i)
-		}
-	}
-	if c.ExpectedRefL2 == 0 {
-		expectedRefL2Num = uint64(0)
-	}
-	expectedRefL2 := mockID(c.ExpectedRefL2, expectedRefL2Num)
+	nextRefL1s, refL2, err := V3FindSyncStart(context.Background(), SyncSourceV2{msr}, genesis)
 
-	nextRefL1, refL2, err := FindSyncStart(context.Background(), msr, genesis)
 	if c.ExpectedErr != nil {
-		assert.Error(t, err, "got next L1 %s (%d), onto L2: %s (%d)", nextRefL1.Hash[:1], nextRefL1.Number, refL2.Hash[:1], refL2.Number)
+		assert.Error(t, err, "Expecting an error in this test case")
 		assert.ErrorIs(t, err, c.ExpectedErr)
 	} else {
+		expectedRefL2 := refToRune(refL2)
+		var expectedRefsL1 []rune
+		for _, ref := range nextRefL1s {
+			expectedRefsL1 = append(expectedRefsL1, refToRune(ref))
+		}
+
 		assert.NoError(t, err)
-		assert.Equal(t, expectedNextRefL1, nextRefL1, "expected %s (nr %d) but got %s (nr %d)", expectedNextRefL1.Hash[:1], expectedNextRefL1.Number, nextRefL1.Hash[:1], nextRefL1.Number)
-		assert.Equal(t, expectedRefL2, refL2, "expected %s (nr %d) but got %s (nr %d)", expectedRefL2.Hash[:1], expectedRefL2.Number, refL2.Hash[:1], refL2.Number)
+		assert.Equal(t, c.ExpectedNextRefsL1, string(expectedRefsL1), "Next L1 refs not equal")
+		assert.Equal(t, expectedRefL2, c.ExpectedRefL2, "Next L2 Head not equal")
 	}
 }
 
 func TestFindSyncStart(t *testing.T) {
 	testCases := []syncStartTestCase{
 		{
-			Name:              "happy extend",
-			OffsetL2:          0,
-			EngineL1:          "ab",
-			EngineL2:          "AB",
-			ActualL1:          "abc",
-			GenesisL1:         'a',
-			GenesisL2:         'A',
-			ExpectedNextRefL1: 'c',
-			ExpectedRefL2:     'B',
-			ExpectedErr:       nil,
+			Name:               "happy extend",
+			OffsetL2:           0,
+			EngineL1:           "ab",
+			EngineL2:           "AB",
+			ActualL1:           "abc",
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			ExpectedNextRefsL1: "c",
+			ExpectedRefL2:      'B',
+			ExpectedErr:        nil,
 		},
 		{
-			Name:              "extend one at a time",
-			OffsetL2:          0,
-			EngineL1:          "ab",
-			EngineL2:          "AB",
-			ActualL1:          "abcdef",
-			GenesisL1:         'a',
-			GenesisL2:         'A',
-			ExpectedNextRefL1: 'c',
-			ExpectedRefL2:     'B',
-			ExpectedErr:       nil,
+			Name:               "extend one at a time",
+			OffsetL2:           0,
+			EngineL1:           "ab",
+			EngineL2:           "AB",
+			ActualL1:           "abcdef",
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			ExpectedNextRefsL1: "cdef",
+			ExpectedRefL2:      'B',
+			ExpectedErr:        nil,
 		},
 		{
-			Name:              "already synced",
-			OffsetL2:          0,
-			EngineL1:          "abcde",
-			EngineL2:          "ABCDE",
-			ActualL1:          "abcde",
-			GenesisL1:         'a',
-			GenesisL2:         'A',
-			ExpectedNextRefL1: 'e',
-			ExpectedRefL2:     'D',
-			ExpectedErr:       nil,
+			Name:               "already synced",
+			OffsetL2:           0,
+			EngineL1:           "abcde",
+			EngineL2:           "ABCDE",
+			ActualL1:           "abcde",
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			ExpectedNextRefsL1: "",
+			ExpectedRefL2:      'E',
+			ExpectedErr:        nil,
 		},
 		{
-			Name:              "genesis",
-			OffsetL2:          0,
-			EngineL1:          "a",
-			EngineL2:          "A",
-			ActualL1:          "a",
-			GenesisL1:         'a',
-			GenesisL2:         'A',
-			ExpectedNextRefL1: 'a',
-			ExpectedRefL2:     0, // actual zero hash before genesis hash
-			ExpectedErr:       nil,
+			Name:               "genesis",
+			OffsetL2:           0,
+			EngineL1:           "a",
+			EngineL2:           "A",
+			ActualL1:           "a",
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			ExpectedNextRefsL1: "",
+			ExpectedRefL2:      'A',
+			ExpectedErr:        nil,
 		},
 		{
-			Name:              "reorg two steps back",
-			OffsetL2:          0,
-			EngineL1:          "abc",
-			EngineL2:          "ABC",
-			ActualL1:          "axy",
-			GenesisL1:         'a',
-			GenesisL2:         'A',
-			ExpectedNextRefL1: 'x',
-			ExpectedRefL2:     'A',
-			ExpectedErr:       nil,
+			Name:               "reorg two steps back",
+			OffsetL2:           0,
+			EngineL1:           "abc",
+			EngineL2:           "ABC",
+			ActualL1:           "axy",
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			ExpectedNextRefsL1: "xy",
+			ExpectedRefL2:      'A',
+			ExpectedErr:        nil,
 		},
 		{
-			Name:              "Orphan block",
-			OffsetL2:          0,
-			EngineL1:          "abcd",
-			EngineL2:          "ABCD",
-			ActualL1:          "abcx",
-			GenesisL1:         'a',
-			GenesisL2:         'A',
-			ExpectedNextRefL1: 'x',
-			ExpectedRefL2:     'C',
-			ExpectedErr:       nil,
+			Name:               "Orphan block",
+			OffsetL2:           0,
+			EngineL1:           "abcd",
+			EngineL2:           "ABCD",
+			ActualL1:           "abcx",
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			ExpectedNextRefsL1: "x",
+			ExpectedRefL2:      'C',
+			ExpectedErr:        nil,
 		},
 		{
-			Name:              "L2 chain ahead",
-			OffsetL2:          0,
-			EngineL1:          "abcdef",
-			EngineL2:          "ABCDEF",
-			ActualL1:          "abc",
-			GenesisL1:         'a',
-			GenesisL2:         'A',
-			ExpectedNextRefL1: 0,
-			ExpectedRefL2:     0,
-			ExpectedErr:       ethereum.NotFound,
+			Name:               "L2 chain ahead",
+			OffsetL2:           0,
+			EngineL1:           "abcdef",
+			EngineL2:           "ABCDEF",
+			ActualL1:           "abc",
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			ExpectedNextRefsL1: "",
+			ExpectedRefL2:      'C',
+			ExpectedErr:        nil,
 		},
 		{
-			Name:              "L2 chain ahead reorg",
-			OffsetL2:          0,
-			EngineL1:          "abcdef",
-			EngineL2:          "ABCDEF",
-			ActualL1:          "abcx",
-			GenesisL1:         'a',
-			GenesisL2:         'A',
-			ExpectedNextRefL1: 'x',
-			ExpectedRefL2:     'C',
-			ExpectedErr:       nil,
+			Name:               "L2 chain ahead reorg",
+			OffsetL2:           0,
+			EngineL1:           "abcdef",
+			EngineL2:           "ABCDEF",
+			ActualL1:           "abcx",
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			ExpectedNextRefsL1: "x",
+			ExpectedRefL2:      'C',
+			ExpectedErr:        nil,
 		},
 		{
-			Name:              "unexpected L1 chain",
-			OffsetL2:          0,
-			EngineL1:          "abcdef",
-			EngineL2:          "ABCDEF",
-			ActualL1:          "xyz",
-			GenesisL1:         'a',
-			GenesisL2:         'A',
-			ExpectedNextRefL1: 0,
-			ExpectedRefL2:     0,
-			ExpectedErr:       WrongChainErr,
+			Name:               "unexpected L1 chain",
+			OffsetL2:           0,
+			EngineL1:           "abcdef",
+			EngineL2:           "ABCDEF",
+			ActualL1:           "xyz",
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			ExpectedNextRefsL1: "",
+			ExpectedRefL2:      0,
+			ExpectedErr:        WrongChainErr,
 		},
 		{
-			Name:              "unexpected L2 chain",
-			OffsetL2:          0,
-			EngineL1:          "abcdef",
-			EngineL2:          "ABCDEF",
-			ActualL1:          "xyz",
-			GenesisL1:         'a',
-			GenesisL2:         'X',
-			ExpectedNextRefL1: 0,
-			ExpectedRefL2:     0,
-			ExpectedErr:       WrongChainErr,
+			Name:               "unexpected L2 chain",
+			OffsetL2:           0,
+			EngineL1:           "abcdef",
+			EngineL2:           "ABCDEF",
+			ActualL1:           "xyz",
+			GenesisL1:          'a',
+			GenesisL2:          'X',
+			ExpectedNextRefsL1: "",
+			ExpectedRefL2:      0,
+			ExpectedErr:        WrongChainErr,
 		},
 		{
-			Name:              "offset L2 genesis extend",
-			OffsetL2:          3,
-			EngineL1:          "def",
-			EngineL2:          "DEF",
-			ActualL1:          "abcdefg",
-			GenesisL1:         'd',
-			GenesisL2:         'D',
-			ExpectedNextRefL1: 'g',
-			ExpectedRefL2:     'F',
-			ExpectedErr:       nil,
+			Name:               "offset L2 genesis extend",
+			OffsetL2:           3,
+			EngineL1:           "def",
+			EngineL2:           "DEF",
+			ActualL1:           "abcdefg",
+			GenesisL1:          'd',
+			GenesisL2:          'D',
+			ExpectedNextRefsL1: "g",
+			ExpectedRefL2:      'F',
+			ExpectedErr:        nil,
 		},
 		{
-			Name:              "offset L2 genesis reorg",
-			OffsetL2:          3,
-			EngineL1:          "defgh",
-			EngineL2:          "DEFGH",
-			ActualL1:          "abcdx",
-			GenesisL1:         'd',
-			GenesisL2:         'D',
-			ExpectedNextRefL1: 'x',
-			ExpectedRefL2:     'D',
-			ExpectedErr:       nil,
+			Name:               "offset L2 genesis reorg",
+			OffsetL2:           3,
+			EngineL1:           "defgh",
+			EngineL2:           "DEFGH",
+			ActualL1:           "abcdx",
+			GenesisL1:          'd',
+			GenesisL2:          'D',
+			ExpectedNextRefsL1: "x",
+			ExpectedRefL2:      'D',
+			ExpectedErr:        nil,
 		},
 		{
-			Name:              "reorg past offset genesis",
-			OffsetL2:          3,
-			EngineL1:          "defgh",
-			EngineL2:          "DEFGH",
-			ActualL1:          "abx",
-			GenesisL1:         'd',
-			GenesisL2:         'D',
-			ExpectedNextRefL1: 0,
-			ExpectedRefL2:     0,
-			ExpectedErr:       WrongChainErr,
+			Name:               "reorg past offset genesis",
+			OffsetL2:           3,
+			EngineL1:           "abcdefgh",
+			EngineL2:           "ABCDEFGH",
+			ActualL1:           "abx",
+			GenesisL1:          'd',
+			GenesisL2:          'D',
+			ExpectedNextRefsL1: "",
+			ExpectedRefL2:      0,
+			ExpectedErr:        WrongChainErr,
 		},
 	}
 

--- a/opnode/rollup/sync/start_test.go
+++ b/opnode/rollup/sync/start_test.go
@@ -34,6 +34,19 @@ func (m *mockSyncReference) RefByL1Num(ctx context.Context, l1Num uint64) (self 
 	return
 }
 
+func (m *mockSyncReference) L1HeadRef(ctx context.Context) (self eth.BlockID, parent eth.BlockID, err error) {
+	l := len(m.L1)
+	if l == 0 {
+		err = ethereum.NotFound
+		return
+	}
+	self = m.L1[l-1]
+	if l-1 > 0 {
+		parent = m.L1[l-1-1]
+	}
+	return
+}
+
 func (m *mockSyncReference) RefByL2Num(ctx context.Context, l2Num *big.Int, genesis *rollup.Genesis) (refL1 eth.BlockID, refL2 eth.BlockID, parentL2 common.Hash, err error) {
 	if len(m.L2) == 0 {
 		panic("bad test, no l2 chain")


### PR DESCRIPTION
**Description**
This implements a new sync algorithm for the sequencing work. It extends the the return of the sync start algorithm to include a sequence of L1 blocks that the rollup driver should use (rather than a single block).

The algorithm to find the common block is changed, but the result should be identical.

In addition, the downloader and sync reference have been modified. The downloader has some stubbed methods that the sequencer code uses. The sync reference (and a couple other methods) now more heavily use the `eth.L1Node` /`eth.L2Node` structure.



**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
