### PR TITLE
ref impl: Verify L2 from batches

### DIFF
--- a/opnode/cmd/main.go
+++ b/opnode/cmd/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/node"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -120,7 +122,18 @@ func NewConfig(ctx *cli.Context) (*node.Config, error) {
 		L2Hash:        L2Hash,
 		L1Hash:        L1Hash,
 		L1Num:         ctx.GlobalUint64(GenesisL2Hash.Name),
+		Rollup: rollup.Config{
+			BlockTime:            2,
+			MaxSequencerTimeDiff: 10,
+			SeqWindowSize:        64,
+			L1ChainID:            big.NewInt(901),
+			// TODO pick defaults
+			FeeRecipientAddress: common.Address{0xff, 0x01},
+			BatchInboxAddress:   common.Address{0xff, 0x02},
+			BatchSenderAddress:  common.Address{0xff, 0x03},
+		},
 	}
+	cfg.Rollup.Genesis = cfg.GetGenesis()
 	if err := cfg.Check(); err != nil {
 		return nil, err
 	}

--- a/opnode/eth/heads.go
+++ b/opnode/eth/heads.go
@@ -8,13 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 )
 
-type HeadSignal struct {
-	Parent BlockID
-	Self   BlockID
-}
-
 // HeadSignalFn is used as callback function to accept head-signals
-type HeadSignalFn func(sig HeadSignal)
+type HeadSignalFn func(sig L1Node)
 
 type NewHeadSource interface {
 	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
@@ -39,7 +34,7 @@ func WatchHeadChanges(ctx context.Context, src NewHeadSource, fn HeadSignalFn) (
 				if height > 0 {
 					parent = BlockID{Hash: header.ParentHash, Number: height - 1}
 				}
-				fn(HeadSignal{Parent: parent, Self: self})
+				fn(L1Node{Parent: parent, Self: self})
 			case err := <-sub.Err():
 				return err
 			case <-ctx.Done():

--- a/opnode/eth/heads.go
+++ b/opnode/eth/heads.go
@@ -9,7 +9,7 @@ import (
 )
 
 // HeadSignalFn is used as callback function to accept head-signals
-type HeadSignalFn func(sig L1Node)
+type HeadSignalFn func(sig L1BlockRef)
 
 type NewHeadSource interface {
 	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
@@ -34,7 +34,7 @@ func WatchHeadChanges(ctx context.Context, src NewHeadSource, fn HeadSignalFn) (
 				if height > 0 {
 					parent = BlockID{Hash: header.ParentHash, Number: height - 1}
 				}
-				fn(L1Node{Parent: parent, Self: self})
+				fn(L1BlockRef{Parent: parent, Self: self})
 			case err := <-sub.Err():
 				return err
 			case <-ctx.Done():

--- a/opnode/eth/id.go
+++ b/opnode/eth/id.go
@@ -21,33 +21,33 @@ func (id BlockID) TerminalString() string {
 	return fmt.Sprintf("%s:%d", id.Hash.TerminalString(), id.Number)
 }
 
-type L2Node struct {
+type L2BlockRef struct {
 	Self     BlockID
-	L2Parent BlockID
-	L1Parent BlockID
+	Parent   BlockID
+	L1Origin BlockID
 }
 
-func (id L2Node) String() string {
+func (id L2BlockRef) String() string {
 	return fmt.Sprintf("%s:%d", id.Self.Hash.String(), id.Self.Number)
 }
 
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
-func (id L2Node) TerminalString() string {
+func (id L2BlockRef) TerminalString() string {
 	return fmt.Sprintf("%s:%d", id.Self.Hash.TerminalString(), id.Self.Number)
 }
 
-type L1Node struct {
+type L1BlockRef struct {
 	Self   BlockID
 	Parent BlockID
 }
 
-func (id L1Node) String() string {
+func (id L1BlockRef) String() string {
 	return fmt.Sprintf("%s:%d", id.Self.Hash.String(), id.Self.Number)
 }
 
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
-func (id L1Node) TerminalString() string {
+func (id L1BlockRef) TerminalString() string {
 	return fmt.Sprintf("%s:%d", id.Self.Hash.TerminalString(), id.Self.Number)
 }

--- a/opnode/l1/source.go
+++ b/opnode/l1/source.go
@@ -72,16 +72,22 @@ func (s Source) Close() {
 }
 
 func (s Source) FetchL1Info(ctx context.Context, id eth.BlockID) (derive.L1Info, error) {
-	block, _, err := s.Fetch(ctx, id)
-	return block, err
+	return s.client.BlockByHash(ctx, id.Hash)
 }
 func (s Source) FetchReceipts(ctx context.Context, id eth.BlockID) ([]*types.Receipt, error) {
 	_, receipts, err := s.Fetch(ctx, id)
 	return receipts, err
 }
-func (s Source) FetchBatches(ctx context.Context, window []eth.BlockID) ([]derive.BatchData, error) {
-	return nil, nil
-}
-func (s Source) FetchL2Info(ctx context.Context, id eth.BlockID) (derive.L2Info, error) {
-	return nil, nil
+
+func (s Source) FetchTransactions(ctx context.Context, window []eth.BlockID) ([]*types.Transaction, error) {
+	var txns []*types.Transaction
+	for _, id := range window {
+		block, err := s.client.BlockByHash(ctx, id.Hash)
+		if err != nil {
+			return nil, err
+		}
+		txns = append(txns, block.Transactions()...)
+	}
+	return txns, nil
+
 }

--- a/opnode/node/node.go
+++ b/opnode/node/node.go
@@ -119,7 +119,7 @@ func (c *OpNode) Start(ctx context.Context) error {
 
 	c.log.Info("Fetching rollup starting point")
 
-	// Feed of eth.L1Node
+	// Feed of eth.L1BlockRef
 	var l1HeadsFeed event.Feed
 
 	c.log.Info("Attaching execution engine(s)")
@@ -128,7 +128,7 @@ func (c *OpNode) Start(ctx context.Context) error {
 		reqCtx, reqCancel := context.WithTimeout(ctx, time.Second*10)
 
 		// driver subscribes to L1 head changes
-		l1SubCh := make(chan eth.L1Node, 10)
+		l1SubCh := make(chan eth.L1BlockRef, 10)
 		l1HeadsFeed.Subscribe(l1SubCh)
 		// start driving engine: sync blocks by deriving them from L1 and driving them into the engine
 		err := eng.Start(reqCtx, l1SubCh)
@@ -144,14 +144,14 @@ func (c *OpNode) Start(ctx context.Context) error {
 		if err != nil {
 			c.log.Warn("resubscribing after failed L1 subscription", "err", err)
 		}
-		return eth.WatchHeadChanges(context.Background(), c.l1Source, func(sig eth.L1Node) {
+		return eth.WatchHeadChanges(context.Background(), c.l1Source, func(sig eth.L1BlockRef) {
 			l1HeadsFeed.Send(sig)
 		})
 	})
 	handleUnsubscribe(l1HeadsSub, "l1 heads subscription failed")
 
 	// subscribe to L1 heads for info
-	l1Heads := make(chan eth.L1Node, 10)
+	l1Heads := make(chan eth.L1BlockRef, 10)
 	l1HeadsFeed.Subscribe(l1Heads)
 
 	c.log.Info("Start-up complete!")

--- a/opnode/node/node.go
+++ b/opnode/node/node.go
@@ -119,7 +119,7 @@ func (c *OpNode) Start(ctx context.Context) error {
 
 	c.log.Info("Fetching rollup starting point")
 
-	// Feed of eth.HeadSignal
+	// Feed of eth.L1Node
 	var l1HeadsFeed event.Feed
 
 	c.log.Info("Attaching execution engine(s)")
@@ -128,7 +128,7 @@ func (c *OpNode) Start(ctx context.Context) error {
 		reqCtx, reqCancel := context.WithTimeout(ctx, time.Second*10)
 
 		// driver subscribes to L1 head changes
-		l1SubCh := make(chan eth.HeadSignal, 10)
+		l1SubCh := make(chan eth.L1Node, 10)
 		l1HeadsFeed.Subscribe(l1SubCh)
 		// start driving engine: sync blocks by deriving them from L1 and driving them into the engine
 		err := eng.Start(reqCtx, l1SubCh)
@@ -144,14 +144,14 @@ func (c *OpNode) Start(ctx context.Context) error {
 		if err != nil {
 			c.log.Warn("resubscribing after failed L1 subscription", "err", err)
 		}
-		return eth.WatchHeadChanges(context.Background(), c.l1Source, func(sig eth.HeadSignal) {
+		return eth.WatchHeadChanges(context.Background(), c.l1Source, func(sig eth.L1Node) {
 			l1HeadsFeed.Send(sig)
 		})
 	})
 	handleUnsubscribe(l1HeadsSub, "l1 heads subscription failed")
 
 	// subscribe to L1 heads for info
-	l1Heads := make(chan eth.HeadSignal, 10)
+	l1Heads := make(chan eth.L1Node, 10)
 	l1HeadsFeed.Subscribe(l1Heads)
 
 	c.log.Info("Start-up complete!")

--- a/opnode/rollup/derive/doc.go
+++ b/opnode/rollup/derive/doc.go
@@ -14,7 +14,3 @@
 //
 // The steps should be keep separate to enable easier testing.
 package derive
-
-// Mock interfaces. TODO: Remove
-type BatchData interface{}
-type L2Info interface{}

--- a/opnode/rollup/derive/invert.go
+++ b/opnode/rollup/derive/invert.go
@@ -36,24 +36,24 @@ type Block interface {
 }
 
 // BlockReferences takes a L2 block and determines which L1 block it was derived from, its L2 parent id, and its own id.
-func BlockReferences(l2Block Block, genesis *rollup.Genesis) (eth.L2Node, error) {
+func BlockReferences(l2Block Block, genesis *rollup.Genesis) (eth.L2BlockRef, error) {
 	self := eth.BlockID{Hash: l2Block.Hash(), Number: l2Block.NumberU64()}
 	if self.Number <= genesis.L2.Number {
 		if self.Hash != genesis.L2.Hash {
-			return eth.L2Node{}, fmt.Errorf("unexpected L2 genesis block: %s, expected %s", self, genesis.L2)
+			return eth.L2BlockRef{}, fmt.Errorf("unexpected L2 genesis block: %s, expected %s", self, genesis.L2)
 		}
-		return eth.L2Node{Self: self, L1Parent: genesis.L1}, nil
+		return eth.L2BlockRef{Self: self, L1Origin: genesis.L1}, nil
 	}
 
 	l2Parent := eth.BlockID{Hash: l2Block.ParentHash(), Number: l2Block.NumberU64() - 1}
 
 	txs := l2Block.Transactions()
 	if len(txs) == 0 || txs[0].Type() != types.DepositTxType {
-		return eth.L2Node{}, fmt.Errorf("l2 block is missing L1 info deposit tx, block hash: %s", l2Block.Hash())
+		return eth.L2BlockRef{}, fmt.Errorf("l2 block is missing L1 info deposit tx, block hash: %s", l2Block.Hash())
 	}
 	l1Number, _, _, l1Hash, err := L1InfoDepositTxData(txs[0].Data())
 	if err != nil {
-		return eth.L2Node{}, fmt.Errorf("failed to parse L1 info deposit tx from L2 block: %v", err)
+		return eth.L2BlockRef{}, fmt.Errorf("failed to parse L1 info deposit tx from L2 block: %v", err)
 	}
-	return eth.L2Node{Self: self, L2Parent: l2Parent, L1Parent: eth.BlockID{Hash: l1Hash, Number: l1Number}}, nil
+	return eth.L2BlockRef{Self: self, Parent: l2Parent, L1Origin: eth.BlockID{Hash: l1Hash, Number: l1Number}}, nil
 }

--- a/opnode/rollup/derive/invert_test.go
+++ b/opnode/rollup/derive/invert_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 type l1MockInfo struct {
-	num     uint64
-	time    uint64
-	hash    common.Hash
-	baseFee *big.Int
+	num       uint64
+	time      uint64
+	hash      common.Hash
+	baseFee   *big.Int
+	mixDigest [32]byte
 }
 
 func (l *l1MockInfo) NumberU64() uint64 {
@@ -30,6 +31,10 @@ func (l *l1MockInfo) Hash() common.Hash {
 
 func (l *l1MockInfo) BaseFee() *big.Int {
 	return l.baseFee
+}
+
+func (l *l1MockInfo) MixDigest() common.Hash {
+	return l.mixDigest
 }
 
 func randomHash(rng *rand.Rand) (out common.Hash) {

--- a/opnode/rollup/derive/payload_attributes.go
+++ b/opnode/rollup/derive/payload_attributes.go
@@ -250,7 +250,7 @@ func PayloadAttributes(config *rollup.Config, l1Info L1Info, receipts []*types.R
 	// Repeating the latest randomness of L1 might not be ideal.
 	randomnessSeed := l2.Bytes32(l1Info.MixDigest())
 
-	// Collect all L2 batches, the bathes may be out-of-order, or possibly missing.
+	// Collect all L2 batches, the batches may be out-of-order, or possibly missing.
 	l2Blocks := make(map[uint64]*l2.PayloadAttributes)
 	highestSeenTimestamp := l1Info.Time()
 	for _, batch := range seqWindow {

--- a/opnode/rollup/derive/payload_attributes.go
+++ b/opnode/rollup/derive/payload_attributes.go
@@ -284,7 +284,6 @@ func PayloadAttributes(config *rollup.Config, l1Info L1Info, receipts []*types.R
 	}
 
 	// fill the gaps and always ensure at least one L2 block
-	// TODO: What happens if `highestSeenTimestamp` start rolling into the next epoch (higher than the next L1 block timestamp)
 	var out []*l2.PayloadAttributes
 	for t := l1Info.Time() + config.BlockTime; t <= highestSeenTimestamp; t += config.BlockTime {
 		if bl, ok := l2Blocks[t]; ok {

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -29,7 +29,7 @@ func NewDriver(cfg rollup.Config, l2 DriverAPI, l1 l1.Source, log log.Logger) *D
 	}
 }
 
-func (d *Driver) Start(ctx context.Context, l1Heads <-chan eth.HeadSignal) error {
+func (d *Driver) Start(ctx context.Context, l1Heads <-chan eth.L1Node) error {
 	return d.s.Start(ctx, l1Heads)
 }
 func (d *Driver) Close() error {

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -30,7 +30,7 @@ func NewDriver(cfg rollup.Config, l2 DriverAPI, l1 l1.Source, log log.Logger) *D
 	}
 }
 
-func (d *Driver) Start(ctx context.Context, l1Heads <-chan eth.L1Node) error {
+func (d *Driver) Start(ctx context.Context, l1Heads <-chan eth.L1BlockRef) error {
 	return d.s.Start(ctx, l1Heads)
 }
 func (d *Driver) Close() error {
@@ -42,11 +42,11 @@ type inputImpl struct {
 	genesis     *rollup.Genesis
 }
 
-func (i *inputImpl) L1Head(ctx context.Context) (eth.L1Node, error) {
+func (i *inputImpl) L1Head(ctx context.Context) (eth.L1BlockRef, error) {
 	return i.chainSource.L1HeadNode(ctx)
 }
 
-func (i *inputImpl) L2Head(ctx context.Context) (eth.L2Node, error) {
+func (i *inputImpl) L2Head(ctx context.Context) (eth.L2BlockRef, error) {
 	return i.chainSource.L2NodeByNumber(ctx, nil)
 
 }
@@ -55,6 +55,6 @@ func (i *inputImpl) L1ChainWindow(ctx context.Context, base eth.BlockID) ([]eth.
 	return sync.FindL1Range(ctx, i.chainSource, base)
 }
 
-func (i *inputImpl) SafeL2Head(ctx context.Context) (eth.L2Node, error) {
+func (i *inputImpl) SafeL2Head(ctx context.Context) (eth.L2BlockRef, error) {
 	return sync.FindSafeL2Head(ctx, i.chainSource, i.genesis)
 }

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -2,130 +2,53 @@ package driver
 
 import (
 	"context"
-	"time"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/l1"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
-	rollupSync "github.com/ethereum-optimism/optimistic-specs/opnode/rollup/sync"
-
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup/sync"
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// keep making many sync steps if we can make sync progress
-const hot = time.Millisecond * 30
-
-// check on sync regularly, but prioritize sync triggers with head updates etc.
-const cold = time.Second * 8
-
-// at least try every minute to sync, even if things are going well
-const max = time.Minute
-
 type Driver struct {
-	log         log.Logger
-	rpc         DriverAPI
-	chainSource rollupSync.ChainSource
-	dl          Downloader
-	l1Heads     <-chan eth.HeadSignal
-	done        chan struct{}
-	state       // embedded engine state
+	s *state
 }
 
 func NewDriver(cfg rollup.Config, l2 DriverAPI, l1 l1.Source, log log.Logger) *Driver {
+	input := &inputImpl{
+		chainSource: sync.NewChainSource(l1, l2, &cfg.Genesis),
+	}
+	output := &outputImpl{
+		Config: cfg,
+		dl:     l1,
+		log:    log,
+		rpc:    l2,
+	}
 	return &Driver{
-		log:         log,
-		rpc:         l2,
-		chainSource: rollupSync.NewChainSource(l1, l2, &cfg.Genesis),
-		dl:          l1,
-		done:        make(chan struct{}),
-		state:       state{Config: cfg},
+		s: NewState(log, cfg, input, output),
 	}
 }
 
 func (d *Driver) Start(ctx context.Context, l1Heads <-chan eth.HeadSignal) error {
-	d.l1Heads = l1Heads
-	if !d.requestUpdate(ctx, d.log, d) {
-		d.log.Error("failed to fetch engine head, defaulting to genesis")
-		d.updateHead(d.state.Config.Genesis.L1, d.state.Config.Genesis.L2)
-	}
-	go d.loop()
-	return nil
+	return d.s.Start(ctx, l1Heads)
 }
 func (d *Driver) Close() error {
-	close(d.done)
-	return nil
+	return d.s.Close()
 }
 
-func (d *Driver) loop() {
-	ctx := context.Background()
-	backoff := cold
-	syncTicker := time.NewTicker(cold)
-	l2HeadPoll := time.NewTicker(time.Second * 14)
+type inputImpl struct {
+	chainSource sync.ChainSource
+}
 
-	// exponential backoff, add 10% each step, up to max.
-	syncBackoff := func() {
-		backoff += backoff / 10
-		if backoff > max {
-			backoff = max
-		}
-		syncTicker.Reset(backoff)
-	}
-	syncQuickly := func() {
-		syncTicker.Reset(hot)
-		backoff = cold
-	}
-	onL2Update := func() {
-		// And we want to slow down requesting the L2 engine for its head (we just changed it ourselves)
-		// Request head if we don't successfully change it in the next 14 seconds.
-		l2HeadPoll.Reset(time.Second * 14)
-	}
-	defer syncTicker.Stop()
-	defer l2HeadPoll.Stop()
+func (i *inputImpl) L1Head(ctx context.Context) (eth.L1Node, error) {
+	return i.chainSource.L1HeadNode(ctx)
+}
 
-	for {
-		select {
-		case <-d.done:
-			return
-		case <-l2HeadPoll.C:
-			ctx, cancel := context.WithTimeout(ctx, time.Second*4)
-			if d.requestUpdate(ctx, d.log, d) {
-				onL2Update()
-			}
-			cancel()
-			continue
-		case l1HeadSig := <-d.l1Heads:
-			ctx, cancel := context.WithTimeout(ctx, time.Second*4)
-			if d.notifyL1Head(ctx, d.log, l1HeadSig, d) {
-				syncQuickly()
-			}
-			cancel()
-			continue
-		case <-syncTicker.C:
-			// If already synced, or in case of failure, we slow down
-			syncBackoff()
-			ctx, cancel := context.WithTimeout(ctx, time.Second*4)
-			if d.requestSync(ctx, d.log, d) {
-				// Successfully stepped toward target. Continue quickly if we are not there yet
-				syncQuickly()
-				onL2Update()
-			}
-			cancel()
-		}
-	}
+func (i *inputImpl) L2Head(ctx context.Context) (eth.L2Node, error) {
+	return i.chainSource.L2NodeByNumber(ctx, nil)
 
 }
 
-// Fulfill the `internalDriver` interface
-
-func (e *Driver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL2 eth.BlockID, err error) {
-	l2Head, err := e.chainSource.L2NodeByNumber(ctx, nil)
-	return l2Head.L1Parent, l2Head.Self, err
-}
-
-func (e *Driver) findSyncStart(ctx context.Context) (nextRefL1s []eth.BlockID, refL2 eth.BlockID, err error) {
-	return rollupSync.FindSyncStart(ctx, e.chainSource, &e.Config.Genesis)
-}
-
-func (e *Driver) driverStep(ctx context.Context, l1Input []eth.BlockID, l2Parent eth.BlockID, l2Finalized eth.BlockID) (l2ID eth.BlockID, err error) {
-	return e.step(ctx, l1Input, l2Parent, l2Finalized.Hash)
+func (i *inputImpl) L1ChainWindow(ctx context.Context, base eth.BlockID) ([]eth.BlockID, error) {
+	return sync.FindL1Range(ctx, i.chainSource, base)
 }

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -43,11 +43,11 @@ type inputImpl struct {
 }
 
 func (i *inputImpl) L1Head(ctx context.Context) (eth.L1BlockRef, error) {
-	return i.chainSource.L1HeadNode(ctx)
+	return i.chainSource.L1HeadBlockRef(ctx)
 }
 
 func (i *inputImpl) L2Head(ctx context.Context) (eth.L2BlockRef, error) {
-	return i.chainSource.L2NodeByNumber(ctx, nil)
+	return i.chainSource.L2BlockRefByNumber(ctx, nil)
 
 }
 

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -17,6 +17,7 @@ type Driver struct {
 func NewDriver(cfg rollup.Config, l2 DriverAPI, l1 l1.Source, log log.Logger) *Driver {
 	input := &inputImpl{
 		chainSource: sync.NewChainSource(l1, l2, &cfg.Genesis),
+		genesis:     &cfg.Genesis,
 	}
 	output := &outputImpl{
 		Config: cfg,
@@ -38,6 +39,7 @@ func (d *Driver) Close() error {
 
 type inputImpl struct {
 	chainSource sync.ChainSource
+	genesis     *rollup.Genesis
 }
 
 func (i *inputImpl) L1Head(ctx context.Context) (eth.L1Node, error) {
@@ -51,4 +53,8 @@ func (i *inputImpl) L2Head(ctx context.Context) (eth.L2Node, error) {
 
 func (i *inputImpl) L1ChainWindow(ctx context.Context, base eth.BlockID) ([]eth.BlockID, error) {
 	return sync.FindL1Range(ctx, i.chainSource, base)
+}
+
+func (i *inputImpl) SafeL2Head(ctx context.Context) (eth.L2Node, error) {
+	return sync.FindSafeL2Head(ctx, i.chainSource, i.genesis)
 }

--- a/opnode/rollup/driver/fake_chain.go
+++ b/opnode/rollup/driver/fake_chain.go
@@ -26,23 +26,23 @@ func fakeID(id rune, num uint64) eth.BlockID {
 	return eth.BlockID{Hash: h, Number: uint64(num)}
 }
 
-func fakeL1Block(self rune, parent rune, num uint64) eth.L1Node {
+func fakeL1Block(self rune, parent rune, num uint64) eth.L1BlockRef {
 	var parentID eth.BlockID
 	if num != 0 {
 		parentID = fakeID(parent, num-1)
 	}
-	return eth.L1Node{Self: fakeID(self, num), Parent: parentID}
+	return eth.L1BlockRef{Self: fakeID(self, num), Parent: parentID}
 }
 
-func fakeL2Block(self rune, parent rune, l1parent eth.BlockID, num uint64) eth.L2Node {
+func fakeL2Block(self rune, parent rune, l1parent eth.BlockID, num uint64) eth.L2BlockRef {
 	var parentID eth.BlockID
 	if num != 0 {
 		parentID = fakeID(parent, num-1)
 	}
-	return eth.L2Node{Self: fakeID(self, num), L2Parent: parentID, L1Parent: l1parent}
+	return eth.L2BlockRef{Self: fakeID(self, num), Parent: parentID, L1Origin: l1parent}
 }
 
-func chainL1(offset uint64, ids string) (out []eth.L1Node) {
+func chainL1(offset uint64, ids string) (out []eth.L1BlockRef) {
 	var prevID rune
 	for i, id := range ids {
 		out = append(out, fakeL1Block(id, prevID, offset+uint64(i)))
@@ -51,7 +51,7 @@ func chainL1(offset uint64, ids string) (out []eth.L1Node) {
 	return
 }
 
-func chainL2(l1 []eth.L1Node, ids string) (out []eth.L2Node) {
+func chainL2(l1 []eth.L1BlockRef, ids string) (out []eth.L2BlockRef) {
 	var prevID rune
 	for i, id := range ids {
 		out = append(out, fakeL2Block(id, prevID, l1[i].Self, uint64(i)))
@@ -61,11 +61,11 @@ func chainL2(l1 []eth.L1Node, ids string) (out []eth.L2Node) {
 }
 
 func NewFakeChainSource(l1 []string, l2 []string, log log.Logger) *fakeChainSource {
-	var l1s [][]eth.L1Node
+	var l1s [][]eth.L1BlockRef
 	for _, l1string := range l1 {
 		l1s = append(l1s, chainL1(0, l1string))
 	}
-	var l2s [][]eth.L2Node
+	var l2s [][]eth.L2BlockRef
 	for i, l2string := range l2 {
 		l2s = append(l2s, chainL2(l1s[i], l2string))
 	}
@@ -80,33 +80,33 @@ func NewFakeChainSource(l1 []string, l2 []string, log log.Logger) *fakeChainSour
 // what the head block is of the L1 and L2 chains. In addition, it enables re-orgs
 // to easily be implemented
 type fakeChainSource struct {
-	l1reorg int            // Index of the L1 chain to be operating on
-	l2reorg int            // Index of the L2 chain to be operating on
-	l1head  int            // Head block of the L1 chain
-	l2head  int            // Head block of the L2 chain
-	l1s     [][]eth.L1Node // l1s[reorg] is the L1 chain in that specific re-org configuration
-	l2s     [][]eth.L2Node // l2s[reorg] is the L2 chain in that specific re-org configuration
+	l1reorg int                // Index of the L1 chain to be operating on
+	l2reorg int                // Index of the L2 chain to be operating on
+	l1head  int                // Head block of the L1 chain
+	l2head  int                // Head block of the L2 chain
+	l1s     [][]eth.L1BlockRef // l1s[reorg] is the L1 chain in that specific re-org configuration
+	l2s     [][]eth.L2BlockRef // l2s[reorg] is the L2 chain in that specific re-org configuration
 	log     log.Logger
 }
 
-func (m *fakeChainSource) L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1Node, error) {
+func (m *fakeChainSource) L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error) {
 	m.log.Trace("L1NodeByNumber", "l1Num", l1Num, "l1Head", m.l1head, "reorg", m.l1reorg)
 	if l1Num > uint64(m.l1head) {
-		return eth.L1Node{}, ethereum.NotFound
+		return eth.L1BlockRef{}, ethereum.NotFound
 	}
 	return m.l1s[m.l1reorg][l1Num], nil
 }
 
-func (m *fakeChainSource) L1HeadNode(ctx context.Context) (eth.L1Node, error) {
+func (m *fakeChainSource) L1HeadNode(ctx context.Context) (eth.L1BlockRef, error) {
 	m.log.Trace("L1HeadNode", "l1Head", m.l1head, "reorg", m.l1reorg)
 	l := len(m.l1s[m.l1reorg])
 	if l == 0 {
-		return eth.L1Node{}, ethereum.NotFound
+		return eth.L1BlockRef{}, ethereum.NotFound
 	}
 	return m.l1s[m.l1reorg][m.l1head], nil
 }
 
-func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (eth.L2Node, error) {
+func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
 	m.log.Trace("L2NodeByNumber", "l2Num", l2Num, "l2Head", m.l2head, "reorg", m.l2reorg)
 	if len(m.l2s[m.l2reorg]) == 0 {
 		panic("bad test, no l2 chain")
@@ -116,19 +116,19 @@ func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (e
 	}
 	i := int(l2Num.Int64())
 	if i > m.l2head {
-		return eth.L2Node{}, ethereum.NotFound
+		return eth.L2BlockRef{}, ethereum.NotFound
 	}
 	return m.l2s[m.l2reorg][i], nil
 }
 
-func (m *fakeChainSource) L2NodeByHash(ctx context.Context, l2Hash common.Hash) (eth.L2Node, error) {
+func (m *fakeChainSource) L2NodeByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
 	m.log.Trace("L2NodeByHash", "l2Hash", l2Hash, "l2Head", m.l2head, "reorg", m.l2reorg)
 	for i, bl := range m.l2s[m.l2reorg] {
 		if bl.Self.Hash == l2Hash {
 			return m.L2NodeByNumber(ctx, big.NewInt(int64(i)))
 		}
 	}
-	return eth.L2Node{}, ethereum.NotFound
+	return eth.L2BlockRef{}, ethereum.NotFound
 }
 
 var _ sync.ChainSource = (*fakeChainSource)(nil)
@@ -149,7 +149,7 @@ func (m *fakeChainSource) reorgL2() {
 	}
 }
 
-func (m *fakeChainSource) setL2Head(head int) eth.L2Node {
+func (m *fakeChainSource) setL2Head(head int) eth.L2BlockRef {
 	m.log.Trace("Set L2 head", "new_head", head, "old_head", m.l2head)
 	m.l2head = head
 	if m.l2head >= len(m.l2s[m.l2reorg]) {
@@ -158,7 +158,7 @@ func (m *fakeChainSource) setL2Head(head int) eth.L2Node {
 	return m.l2s[m.l2reorg][m.l2head]
 }
 
-func (m *fakeChainSource) advanceL1() eth.L1Node {
+func (m *fakeChainSource) advanceL1() eth.L1BlockRef {
 	m.log.Trace("Advance L1", "new_head", m.l1head+1, "old_head", m.l1head)
 	m.l1head++
 	if m.l1head >= len(m.l1s[m.l1reorg]) {
@@ -167,13 +167,13 @@ func (m *fakeChainSource) advanceL1() eth.L1Node {
 	return m.l1s[m.l1reorg][m.l1head]
 }
 
-func (m *fakeChainSource) l1Head() eth.L1Node {
+func (m *fakeChainSource) l1Head() eth.L1BlockRef {
 	m.log.Trace("L1 Head", "head", m.l1head)
 	return m.l1s[m.l1reorg][m.l1head]
 }
 
 // Unused functions
-// func (m *fakeChainSource) advanceL2() eth.L2Node {
+// func (m *fakeChainSource) advanceL2() eth.L2BlockRef {
 // 	m.log.Trace("Advance L2", "new_head", m.l2head+1, "old_head", m.l2head)
 // 	m.l2head++
 // 	if m.l2head >= len(m.l2s[m.l1reorg]) {
@@ -181,7 +181,7 @@ func (m *fakeChainSource) l1Head() eth.L1Node {
 // 	}
 // 	return m.l2s[m.l1reorg][m.l2head]
 // }
-// func (m *fakeChainSource) l2Head() eth.L2Node {
+// func (m *fakeChainSource) l2Head() eth.L2BlockRef {
 // 	m.log.Trace("L2 Head", "head", m.l2head)
 // 	return m.l2s[m.reorg][m.l2head]
 // }

--- a/opnode/rollup/driver/fake_chain.go
+++ b/opnode/rollup/driver/fake_chain.go
@@ -171,17 +171,3 @@ func (m *fakeChainSource) l1Head() eth.L1BlockRef {
 	m.log.Trace("L1 Head", "head", m.l1head)
 	return m.l1s[m.l1reorg][m.l1head]
 }
-
-// Unused functions
-// func (m *fakeChainSource) advanceL2() eth.L2BlockRef {
-// 	m.log.Trace("Advance L2", "new_head", m.l2head+1, "old_head", m.l2head)
-// 	m.l2head++
-// 	if m.l2head >= len(m.l2s[m.l1reorg]) {
-// 		panic("Cannot advance L2 past end of chain")
-// 	}
-// 	return m.l2s[m.l1reorg][m.l2head]
-// }
-// func (m *fakeChainSource) l2Head() eth.L2BlockRef {
-// 	m.log.Trace("L2 Head", "head", m.l2head)
-// 	return m.l2s[m.reorg][m.l2head]
-// }

--- a/opnode/rollup/driver/fake_chain.go
+++ b/opnode/rollup/driver/fake_chain.go
@@ -1,0 +1,163 @@
+package driver
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup/sync"
+)
+
+func fakeID(id rune, num uint64) eth.BlockID {
+	var h common.Hash
+	copy(h[:], string(id))
+	return eth.BlockID{Hash: h, Number: uint64(num)}
+}
+
+func fakeL1Block(self rune, parent rune, num uint64) eth.L1Node {
+	var parentID eth.BlockID
+	if num != 0 {
+		parentID = fakeID(parent, num-1)
+	}
+	return eth.L1Node{Self: fakeID(self, num), Parent: parentID}
+}
+
+func fakeL2Block(self rune, parent rune, l1parent eth.BlockID, num uint64) eth.L2Node {
+	var parentID eth.BlockID
+	if num != 0 {
+		parentID = fakeID(parent, num-1)
+	}
+	return eth.L2Node{Self: fakeID(self, num), L2Parent: parentID, L1Parent: l1parent}
+}
+
+func chainL1(offset uint64, ids string) (out []eth.L1Node) {
+	var prevID rune
+	for i, id := range ids {
+		out = append(out, fakeL1Block(id, prevID, offset+uint64(i)))
+		prevID = id
+	}
+	return
+}
+
+func chainL2(l1 []eth.L1Node, ids string) (out []eth.L2Node) {
+	var prevID rune
+	for i, id := range ids {
+		out = append(out, fakeL2Block(id, prevID, l1[i].Self, uint64(i)))
+		prevID = id
+	}
+	return
+}
+
+func NewFakeChainSource(l1 []string, l2 []string, log log.Logger) *fakeChainSource {
+	var l1s [][]eth.L1Node
+	for _, l1string := range l1 {
+		l1s = append(l1s, chainL1(0, l1string))
+	}
+	var l2s [][]eth.L2Node
+	for i, l2string := range l2 {
+		l2s = append(l2s, chainL2(l1s[i], l2string))
+	}
+	return &fakeChainSource{
+		l1s: l1s,
+		l2s: l2s,
+		log: log,
+	}
+}
+
+// fakeChainSource implements the ChainSource interface with the ability to control
+// what the head block is of the L1 and L2 chains. In addition, it enables re-orgs
+// to easily be implemented
+type fakeChainSource struct {
+	reorg  int            // Index of which chain to be operating on
+	l1head int            // Head block of the L1 chain
+	l2head int            // Head block of the L2 chain
+	l1s    [][]eth.L1Node // l1s[reorg] is the L1 chain in that specific re-org configuration
+	l2s    [][]eth.L2Node // l2s[reorg] is the L2 chain in that specific re-org configuration
+	log    log.Logger
+}
+
+func (m *fakeChainSource) L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1Node, error) {
+	m.log.Trace("L1NodeByNumber", "l1Num", l1Num, "l1Head", m.l1head, "reorg", m.reorg)
+	if l1Num > uint64(m.l1head) {
+		return eth.L1Node{}, ethereum.NotFound
+	}
+	return m.l1s[m.reorg][l1Num], nil
+}
+
+func (m *fakeChainSource) L1HeadNode(ctx context.Context) (eth.L1Node, error) {
+	m.log.Trace("L1HeadNode", "l1Head", m.l1head, "reorg", m.reorg)
+	l := len(m.l1s[m.reorg])
+	if l == 0 {
+		return eth.L1Node{}, ethereum.NotFound
+	}
+	return m.l1s[m.reorg][m.l1head], nil
+}
+
+func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (eth.L2Node, error) {
+	m.log.Trace("L2NodeByNumber", "l2Num", l2Num, "l2Head", m.l2head, "reorg", m.reorg)
+	if len(m.l2s[m.reorg]) == 0 {
+		panic("bad test, no l2 chain")
+	}
+	if l2Num == nil {
+		return m.l2s[m.reorg][m.l2head], nil
+	}
+	i := int(l2Num.Int64())
+	if i > m.l2head {
+		return eth.L2Node{}, ethereum.NotFound
+	}
+	return m.l2s[m.reorg][i], nil
+}
+
+func (m *fakeChainSource) L2NodeByHash(ctx context.Context, l2Hash common.Hash) (eth.L2Node, error) {
+	m.log.Trace("L2NodeByHash", "l2Hash", l2Hash, "l2Head", m.l2head, "reorg", m.reorg)
+	for i, bl := range m.l2s[m.reorg] {
+		if bl.Self.Hash == l2Hash {
+			return m.L2NodeByNumber(ctx, big.NewInt(int64(i)))
+		}
+	}
+	return eth.L2Node{}, ethereum.NotFound
+}
+
+var _ sync.ChainSource = (*fakeChainSource)(nil)
+
+func (m *fakeChainSource) reorgChains(reorgBase int) {
+	m.log.Trace("Reorg", "new_reorg", m.reorg+1, "old_reorg", m.reorg)
+	m.reorg++
+	if m.reorg >= len(m.l1s) {
+		panic("No more re-org chains available")
+	}
+	m.l2head = reorgBase
+}
+
+func (m *fakeChainSource) advanceL1() eth.L1Node {
+	m.log.Trace("Advance L1", "new_head", m.l1head+1, "old_head", m.l1head)
+	m.l1head++
+	if m.l1head >= len(m.l1s[m.reorg]) {
+		panic("Cannot advance L1 past end of chain")
+	}
+	return m.l1s[m.reorg][m.l1head]
+}
+
+func (m *fakeChainSource) l1Head() eth.L1Node {
+	m.log.Trace("L1 Head", "head", m.l1head)
+	return m.l1s[m.reorg][m.l1head]
+}
+
+func (m *fakeChainSource) advanceL2() eth.L2Node {
+	m.log.Trace("Advance L2", "new_head", m.l2head+1, "old_head", m.l2head)
+	m.l2head++
+	if m.l2head >= len(m.l2s[m.reorg]) {
+		panic("Cannot advance L2 past end of chain")
+	}
+	return m.l2s[m.reorg][m.l2head]
+}
+
+// unused
+// func (m *fakeChainSource) l2Head() eth.L2Node {
+// 	m.log.Trace("L2 Head", "head", m.l2head)
+// 	return m.l2s[m.reorg][m.l2head]
+// }

--- a/opnode/rollup/driver/fake_chain.go
+++ b/opnode/rollup/driver/fake_chain.go
@@ -89,16 +89,16 @@ type fakeChainSource struct {
 	log     log.Logger
 }
 
-func (m *fakeChainSource) L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error) {
-	m.log.Trace("L1NodeByNumber", "l1Num", l1Num, "l1Head", m.l1head, "reorg", m.l1reorg)
+func (m *fakeChainSource) L1BlockRefByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error) {
+	m.log.Trace("L1BlockRefByNumber", "l1Num", l1Num, "l1Head", m.l1head, "reorg", m.l1reorg)
 	if l1Num > uint64(m.l1head) {
 		return eth.L1BlockRef{}, ethereum.NotFound
 	}
 	return m.l1s[m.l1reorg][l1Num], nil
 }
 
-func (m *fakeChainSource) L1HeadNode(ctx context.Context) (eth.L1BlockRef, error) {
-	m.log.Trace("L1HeadNode", "l1Head", m.l1head, "reorg", m.l1reorg)
+func (m *fakeChainSource) L1HeadBlockRef(ctx context.Context) (eth.L1BlockRef, error) {
+	m.log.Trace("L1HeadBlockRef", "l1Head", m.l1head, "reorg", m.l1reorg)
 	l := len(m.l1s[m.l1reorg])
 	if l == 0 {
 		return eth.L1BlockRef{}, ethereum.NotFound
@@ -106,8 +106,8 @@ func (m *fakeChainSource) L1HeadNode(ctx context.Context) (eth.L1BlockRef, error
 	return m.l1s[m.l1reorg][m.l1head], nil
 }
 
-func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
-	m.log.Trace("L2NodeByNumber", "l2Num", l2Num, "l2Head", m.l2head, "reorg", m.l2reorg)
+func (m *fakeChainSource) L2BlockRefByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
+	m.log.Trace("L2BlockRefByNumber", "l2Num", l2Num, "l2Head", m.l2head, "reorg", m.l2reorg)
 	if len(m.l2s[m.l2reorg]) == 0 {
 		panic("bad test, no l2 chain")
 	}
@@ -121,11 +121,11 @@ func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (e
 	return m.l2s[m.l2reorg][i], nil
 }
 
-func (m *fakeChainSource) L2NodeByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
-	m.log.Trace("L2NodeByHash", "l2Hash", l2Hash, "l2Head", m.l2head, "reorg", m.l2reorg)
+func (m *fakeChainSource) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
+	m.log.Trace("L2BlockRefByHash", "l2Hash", l2Hash, "l2Head", m.l2head, "reorg", m.l2reorg)
 	for i, bl := range m.l2s[m.l2reorg] {
 		if bl.Self.Hash == l2Hash {
-			return m.L2NodeByNumber(ctx, big.NewInt(int64(i)))
+			return m.L2BlockRefByNumber(ctx, big.NewInt(int64(i)))
 		}
 	}
 	return eth.L2BlockRef{}, ethereum.NotFound

--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -37,8 +37,8 @@ type state struct {
 	// The L1 block we are syncing towards, may be ahead of l1Head
 	l1Target eth.BlockID
 
-	// Genesis starting point
-	Genesis rollup.Genesis
+	// Rollup config
+	Config rollup.Config
 }
 
 func (e *state) updateHead(l1Head eth.BlockID, l2Head eth.BlockID) {

--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -31,7 +31,7 @@ type state struct {
 	Config rollup.Config
 
 	// Connections (in/out)
-	l1Heads <-chan eth.HeadSignal
+	l1Heads <-chan eth.L1Node
 	input   inputInterface
 	output  outputInterface
 
@@ -75,7 +75,7 @@ func NewState(log log.Logger, config rollup.Config, input inputInterface, output
 	}
 }
 
-func (s *state) Start(ctx context.Context, l1Heads <-chan eth.HeadSignal) error {
+func (s *state) Start(ctx context.Context, l1Heads <-chan eth.L1Node) error {
 	l1Head, err := s.input.L1Head(ctx)
 	if err != nil {
 		return err
@@ -99,7 +99,7 @@ func (s *state) Close() error {
 	return nil
 }
 
-func (s *state) handleReorg(ctx context.Context, head eth.HeadSignal) error {
+func (s *state) handleReorg(ctx context.Context, head eth.L1Node) error {
 	log.Warn("L1 Head signal indicates an L1 re-org", "old_l1_head", s.l1Head, "new_l1_head_parent", head.Parent, "new_l1_head", head.Self)
 	nextL2Head, err := s.input.L2Head(ctx)
 	if err != nil {
@@ -119,7 +119,7 @@ func (s *state) handleReorg(ctx context.Context, head eth.HeadSignal) error {
 // If there is a re-org, this updates the internal state to handle the re-org.
 // Note that `ctx` is only used in a re-org and that handling a re-org may take a long period of time.
 // The L2 engine is not modified in this function.
-func (s *state) newL1Head(ctx context.Context, head eth.HeadSignal) (bool, error) {
+func (s *state) newL1Head(ctx context.Context, head eth.L1Node) (bool, error) {
 	// Already have head
 	if s.l1Head == head.Self {
 		log.Trace("Received L1 head signal that is the same as the current head", "l1_head", head.Self)

--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -189,6 +189,7 @@ func (s *state) loop() {
 
 		case <-stepRequest:
 			log := s.log.New("action", "step_request", "cached_window_len", len(s.l1Window), "l1Head", s.l1Head, "l2Head", s.l2Head, "l1Base", s.l1Base)
+			log.Trace("Got step request")
 			// Extended cached window if we do not have enough saved blocks
 			if len(s.l1Window) < int(s.Config.SeqWindowSize) {
 				err := s.extendL1Window(context.Background())

--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -16,11 +16,11 @@ type internalDriver interface {
 	// findSyncStart statelessly finds the next L1 block to derive, and on which L2 block it applies.
 	// If the engine is fully synced, then the last derived L1 block, and parent L2 block, is repeated.
 	// An error is returned if the sync starting point could not be determined (due to timeouts, wrong-chain, etc.)
-	findSyncStart(ctx context.Context) (nextRefL1 eth.BlockID, refL2 eth.BlockID, err error)
+	findSyncStart(ctx context.Context) (nextRefL1s []eth.BlockID, refL2 eth.BlockID, err error)
 	// driverStep explicitly calls the engine to derive a L1 block into a L2 block, and apply it on top of the given L2 block.
 	// The finalized L2 block is provided to update the engine with finality, but does not affect the derivation step itself.
 	// The resulting L2 block ID is returned, or an error if the derivation fails.
-	driverStep(ctx context.Context, nextRefL1 eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error)
+	driverStep(ctx context.Context, nextRefL1s []eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error)
 }
 
 type state struct {
@@ -33,6 +33,12 @@ type state struct {
 	// l2Finalized tracks the block the engine can safely regard as irreversible
 	// (a week for disputes, or maybe shorter if we see L1 finalize and take the derived L2 chain up till there)
 	l2Finalized eth.BlockID
+
+	// l1Next buffers the next L1 block IDs to derive new L2 blocks from, with increasing block height.
+	l1Next []eth.BlockID
+	// l2NextParent buffers the L2 Block ID to build on with l1Next.
+	// This may not be in sync with the l2Head in case of reorgs.
+	l2NextParent eth.BlockID
 
 	// The L1 block we are syncing towards, may be ahead of l1Head
 	l1Target eth.BlockID
@@ -63,29 +69,57 @@ func (e *state) requestUpdate(ctx context.Context, log log.Logger, driver intern
 // requestSync tries to sync the provided driver towards the sync target of the state-machine.
 // If the L2 syncs a step, but is not finished yet, it will return true. False otherwise.
 func (e *state) requestSync(ctx context.Context, log log.Logger, driver internalDriver) (l2Updated bool) {
+	log = log.New("l1_head", e.l1Head, "l2_head", e.l2Head)
 	if e.l1Head == e.l1Target {
-		log.Debug("Engine is fully synced", "l1_head", e.l1Head, "l2_head", e.l2Head)
+		log.Debug("Engine is fully synced")
 		// TODO: even though we are fully synced, it may be worth attempting anyway,
 		// in case the e.l1Head is not updating (failed/broken L1 head subscription)
 		return false
 	}
-	log.Debug("finding next sync step, engine syncing", "l2", e.l2Head, "l1", e.l1Head)
-	nextRefL1, refL2, err := driver.findSyncStart(ctx)
-	if err != nil {
-		log.Error("Failed to find sync starting point", "err", err)
+	// If the engine is not in sync with our previous sync preparation, then we need to reconstruct the buffered L1 ids
+	if e.l2Head != e.l2NextParent {
+		log.Debug("finding next sync step, engine syncing", "buffered_l2", e.l2NextParent)
+		nextL1s, refL2, err := driver.findSyncStart(ctx)
+		if err != nil {
+			log.Error("Failed to find sync starting point", "err", err)
+			return false
+		}
+		e.l1Next = nextL1s
+		e.l2NextParent = refL2
+	} else {
+		log.Debug("attempting new sync step")
+	}
+
+	return e.applyNextWindow(ctx, log, driver)
+}
+
+func (e *state) applyNextWindow(ctx context.Context, log log.Logger, driver internalDriver) (l2Updated bool) {
+	// If the engine moved faster than our buffer try to move the buffer forward, do not get stuck.
+	for i, id := range e.l1Next {
+		if e.l1Head == id {
+			log.Debug("Engine is ahead of rollup node, skipping forward and aborting sync")
+			e.l1Next = e.l1Next[i+1:]
+			e.l2NextParent = e.l2Head
+			return true
+		}
+	}
+	if uint64(len(e.l1Next)) < e.Config.SeqWindowSize {
+		log.Warn("Not enough known L1 blocks for sequencing window, skipping sync")
 		return false
 	}
-	if nextRefL1 == e.l1Head {
-		log.Debug("Engine is already synced, aborting sync", "l1_head", e.l1Head, "l2_head", e.l2Head)
-		return false
-	}
-	if l2ID, err := driver.driverStep(ctx, nextRefL1, refL2, e.l2Finalized); err != nil {
-		log.Error("Failed to sync L2 chain with new L1 block", "l1", nextRefL1, "onto_l2", refL2, "err", err)
+	seqWindow := e.l1Next[:e.Config.SeqWindowSize]
+	log = log.New("l1_window_start", seqWindow[0], "onto_l2", e.l2NextParent)
+	if l2ID, err := driver.driverStep(ctx, seqWindow, e.l2NextParent, e.l2Finalized); err != nil {
+		log.Error("Failed to sync L2 chain with new L1 block", "stopped_at", l2ID, "err", err)
 		return false
 	} else {
-		e.updateHead(nextRefL1, l2ID) // l2ID is derived from the nextRefL1
+		log.Debug("Finished driver step", "l1_head", seqWindow[0], "l2_head", l2ID)
+		e.updateHead(seqWindow[0], l2ID) // l2ID is derived from the nextRefL1
+		// shift sequencing window: batches overlap, but we continue deposit/l1info processing from the next block.
+		e.l1Next = e.l1Next[1:]
+		e.l2NextParent = l2ID
+		return true
 	}
-	return e.l1Head != e.l1Target
 }
 
 // notifyL1Head updates the state-machine with the L1 signal,
@@ -96,24 +130,19 @@ func (e *state) notifyL1Head(ctx context.Context, log log.Logger, l1HeadSig eth.
 		log.Debug("Received L1 head signal, already synced to it, ignoring event", "l1_head", e.l1Head)
 		return
 	}
-	if e.l1Head == l1HeadSig.Parent {
-		// Simple extend, a linear life is easy
-		if l2ID, err := driver.driverStep(ctx, l1HeadSig.Self, e.l2Head, e.l2Finalized); err != nil {
-			log.Error("Failed to extend L2 chain with new L1 block", "l1", l1HeadSig.Self, "l2", e.l2Head, "err", err)
-			// Retry sync later
-			e.l1Target = l1HeadSig.Self
-			return false
-		} else {
-			e.updateHead(l1HeadSig.Self, l2ID)
-			return true
+	e.l1Target = l1HeadSig.Self
+	// Check if this is a simple extension on top of previous buffered L1 chain we already know of
+	if len(e.l1Next) > 0 && e.l1Next[len(e.l1Next)-1] == l1HeadSig.Parent {
+		// don't buffer more than 20 sequencing windows  (TBD, sanity limit)
+		if uint64(len(e.l1Next)) < e.Config.SeqWindowSize*20 {
+			e.l1Next = append(e.l1Next, l1HeadSig.Self)
 		}
+		return e.applyNextWindow(ctx, log, driver)
 	}
 	if e.l1Head.Number < l1HeadSig.Parent.Number {
 		log.Debug("Received new L1 head, engine is out of sync, cannot immediately process", "l1", l1HeadSig.Self, "l2", e.l2Head)
 	} else {
 		log.Warn("Received a L1 reorg, syncing new alternative chain", "l1", l1HeadSig.Self, "l2", e.l2Head)
 	}
-
-	e.l1Target = l1HeadSig.Self
 	return false
 }

--- a/opnode/rollup/driver/state_test.go
+++ b/opnode/rollup/driver/state_test.go
@@ -1,139 +1,139 @@
 package driver
 
-import (
-	"context"
-	"math/big"
-	"strconv"
-	"strings"
-	"testing"
+// import (
+// 	"context"
+// 	"math/big"
+// 	"strconv"
+// 	"strings"
+// 	"testing"
 
-	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
-	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testlog"
-	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-)
+// 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+// 	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testlog"
+// 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+// 	"github.com/ethereum/go-ethereum/common"
+// 	"github.com/ethereum/go-ethereum/log"
+// 	"github.com/stretchr/testify/assert"
+// 	"github.com/stretchr/testify/mock"
+// )
 
-type testID string
+// type testID string
 
-func (id testID) ID() eth.BlockID {
-	parts := strings.Split(string(id), ":")
-	if len(parts) != 2 {
-		panic("bad id")
-	}
-	if len(parts[0]) > 32 {
-		panic("test ID hash too long")
-	}
-	var h common.Hash
-	copy(h[:], parts[0])
-	v, err := strconv.ParseUint(parts[1], 0, 64)
-	if err != nil {
-		panic(err)
-	}
-	return eth.BlockID{
-		Hash:   h,
-		Number: v,
-	}
-}
+// func (id testID) ID() eth.BlockID {
+// 	parts := strings.Split(string(id), ":")
+// 	if len(parts) != 2 {
+// 		panic("bad id")
+// 	}
+// 	if len(parts[0]) > 32 {
+// 		panic("test ID hash too long")
+// 	}
+// 	var h common.Hash
+// 	copy(h[:], parts[0])
+// 	v, err := strconv.ParseUint(parts[1], 0, 64)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	return eth.BlockID{
+// 		Hash:   h,
+// 		Number: v,
+// 	}
+// }
 
-type testState struct {
-	l1Head      testID
-	l2Head      testID
-	l2Finalized testID
-	l1Target    testID
+// type testState struct {
+// 	l1Head      testID
+// 	l1Base      testID
+// 	l2Head      testID
+// 	l2Finalized testID
 
-	l1Next       []testID
-	l2NextParent testID
+// 	l1Window    []testID
+// 	l1WindowEnd testID
 
-	genesisL1 testID
-	genesisL2 testID
+// 	genesisL1 testID
+// 	genesisL2 testID
 
-	seqWindowSize uint64
-}
+// 	seqWindowSize uint64
+// }
 
-func makeState(st testState) *state {
-	next := make([]eth.BlockID, len(st.l1Next))
-	for i, id := range st.l1Next {
-		next[i] = id.ID()
-	}
-	return &state{
-		l1Head:       st.l1Head.ID(),
-		l2Head:       st.l2Head.ID(),
-		l2Finalized:  st.l2Finalized.ID(),
-		l1Target:     st.l1Target.ID(),
-		l1Next:       next,
-		l2NextParent: st.l2NextParent.ID(),
-		// TODO: improve testing config (test different seq window sizes and non-zero L2 genesis time?)
-		Config: rollup.Config{
-			Genesis: rollup.Genesis{
-				L1:     st.genesisL1.ID(),
-				L2:     st.genesisL2.ID(),
-				L2Time: 0,
-			},
-			BlockTime:            2,
-			MaxSequencerTimeDiff: 10,
-			SeqWindowSize:        st.seqWindowSize,
-			L1ChainID:            big.NewInt(100),
-			FeeRecipientAddress:  common.Address{0x0a},
-			BatchInboxAddress:    common.Address{0x0b},
-			BatchSenderAddress:   common.Address{0x0c},
-		},
-	}
-}
+// func makeState(st testState) *state {
+// 	window := make([]eth.BlockID, len(st.l1Window))
+// 	for i, id := range st.l1Window {
+// 		window[i] = id.ID()
+// 	}
+// 	return &state{
+// 		l1Head:      st.l1Head.ID(),
+// 		l2Head:      st.l2Head.ID(),
+// 		l2Finalized: st.l2Finalized.ID(),
+// 		l1Base:      st.l1Base.ID(),
+// 		l1Window:    window,
+// 		l1WindowEnd: st.l1WindowEnd.ID(),
+// 		// TODO: improve testing config (test different seq window sizes and non-zero L2 genesis time?)
+// 		Config: rollup.Config{
+// 			Genesis: rollup.Genesis{
+// 				L1:     st.genesisL1.ID(),
+// 				L2:     st.genesisL2.ID(),
+// 				L2Time: 0,
+// 			},
+// 			BlockTime:            2,
+// 			MaxSequencerTimeDiff: 10,
+// 			SeqWindowSize:        st.seqWindowSize,
+// 			L1ChainID:            big.NewInt(100),
+// 			FeeRecipientAddress:  common.Address{0x0a},
+// 			BatchInboxAddress:    common.Address{0x0b},
+// 			BatchSenderAddress:   common.Address{0x0c},
+// 		},
+// 	}
+// }
 
-type mockDriver struct {
-	mock.Mock
-}
+// type mockDriver struct {
+// 	mock.Mock
+// }
 
-func (m *mockDriver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL2 eth.BlockID, err error) {
-	returnArgs := m.Called(ctx)
-	refL1 = returnArgs.Get(0).(eth.BlockID)
-	refL2 = returnArgs.Get(1).(eth.BlockID)
-	err = returnArgs.Get(2).(error)
-	return
-}
+// func (m *mockDriver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL2 eth.BlockID, err error) {
+// 	returnArgs := m.Called(ctx)
+// 	refL1 = returnArgs.Get(0).(eth.BlockID)
+// 	refL2 = returnArgs.Get(1).(eth.BlockID)
+// 	err = returnArgs.Get(2).(error)
+// 	return
+// }
 
-func (m *mockDriver) findSyncStart(ctx context.Context) (nextL1s []eth.BlockID, refL2 eth.BlockID, err error) {
-	returnArgs := m.Called(ctx)
-	nextL1s = returnArgs.Get(0).([]eth.BlockID)
-	refL2 = returnArgs.Get(1).(eth.BlockID)
-	err, _ = returnArgs.Get(2).(error)
-	return
-}
+// func (m *mockDriver) findSyncStart(ctx context.Context) (nextL1s []eth.BlockID, refL2 eth.BlockID, err error) {
+// 	returnArgs := m.Called(ctx)
+// 	nextL1s = returnArgs.Get(0).([]eth.BlockID)
+// 	refL2 = returnArgs.Get(1).(eth.BlockID)
+// 	err, _ = returnArgs.Get(2).(error)
+// 	return
+// }
 
-func (m *mockDriver) driverStep(ctx context.Context, seqWindow []eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error) {
-	returnArgs := m.Called(ctx, seqWindow, refL2, finalized)
-	l2ID = returnArgs.Get(0).(eth.BlockID)
-	err, _ = returnArgs.Get(1).(error)
-	return
-}
+// func (m *mockDriver) driverStep(ctx context.Context, seqWindow []eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error) {
+// 	returnArgs := m.Called(ctx, seqWindow, refL2, finalized)
+// 	l2ID = returnArgs.Get(0).(eth.BlockID)
+// 	err, _ = returnArgs.Get(1).(error)
+// 	return
+// }
 
-var _ internalDriver = (*mockDriver)(nil)
+// var _ internalDriver = (*mockDriver)(nil)
 
-func TestEngineDriverState_RequestSync(t *testing.T) {
-	log := testlog.Logger(t, log.LvlTrace)
-	driver := new(mockDriver)
-	ctx := context.Background()
+// func TestEngineDriverState_RequestSync(t *testing.T) {
+// 	log := testlog.Logger(t, log.LvlTrace)
+// 	driver := new(mockDriver)
+// 	ctx := context.Background()
 
-	state := makeState(testState{
-		l1Head:        "c:2",
-		l2Head:        "C:2",
-		l2Finalized:   "B:1",
-		l1Target:      "e:4",
-		l1Next:        []testID{"d:3", "e:4", "c:5"}, // TODO: multiple batches per L1 block
-		l2NextParent:  "C:2",
-		genesisL1:     "a:0",
-		genesisL2:     "b:0",
-		seqWindowSize: 1, // TODO: test larger sequencing sizes (requires updating test below)
-	})
-	driver.On("findSyncStart", ctx).Return([]eth.BlockID{testID("d:3").ID()}, testID("C:2").ID(), nil)
-	driver.On("driverStep", ctx, []eth.BlockID{testID("d:3").ID()}, testID("C:2").ID(), testID("B:1").ID()).Return(testID("D:3").ID(), nil)
+// 	state := makeState(testState{
+// 		l1Head:        "e:4",
+// 		l1Base:        "c:2",
+// 		l2Head:        "C:2",
+// 		l2Finalized:   "B:1",
+// 		l1Window:      []testID{"d:3", "e:4", "c:5"}, // TODO: multiple batches per L1 block
+// 		l1WindowEnd:   "c:5",
+// 		genesisL1:     "a:0",
+// 		genesisL2:     "b:0",
+// 		seqWindowSize: 1, // TODO: test larger sequencing sizes (requires updating test below)
+// 	})
+// 	driver.On("findSyncStart", ctx).Return([]eth.BlockID{testID("d:3").ID()}, testID("C:2").ID(), nil)
+// 	driver.On("driverStep", ctx, []eth.BlockID{testID("d:3").ID()}, testID("C:2").ID(), testID("B:1").ID()).Return(testID("D:3").ID(), nil)
 
-	l2Updated := state.requestSync(ctx, log, driver)
+// 	l2Updated := state.requestSync(ctx, log, driver)
 
-	assert.Equal(t, state.l1Head, testID("d:3").ID())
-	assert.Equal(t, state.l2Head, testID("D:3").ID())
-	assert.True(t, l2Updated)
-}
+// 	assert.Equal(t, state.l1Head, testID("d:3").ID())
+// 	assert.Equal(t, state.l2Head, testID("D:3").ID())
+// 	assert.True(t, l2Updated)
+// }

--- a/opnode/rollup/driver/state_test.go
+++ b/opnode/rollup/driver/state_test.go
@@ -59,20 +59,20 @@ type stateTestCaseStep struct {
 	expectedL2Head testID
 	expectedWindow []testID
 
-	l1action func(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1Node)
+	l1action func(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1BlockRef)
 	l2action func(t *testing.T, expectedWindow []testID, s *state, src *fakeChainSource, outputIn chan outputArgs, outputReturn chan outputReturnArgs)
 	reorg    bool
 }
 
-func advanceL1(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1Node) {
+func advanceL1(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1BlockRef) {
 	l1Heads <- src.advanceL1()
 }
 
-func stutterL1(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1Node) {
+func stutterL1(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1BlockRef) {
 	l1Heads <- src.l1Head()
 }
 
-func stutterAdvance(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1Node) {
+func stutterAdvance(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1BlockRef) {
 	l1Heads <- src.l1Head()
 	l1Heads <- src.l1Head()
 	l1Heads <- src.l1Head()
@@ -123,7 +123,7 @@ type stateTestCase struct {
 func (tc *stateTestCase) Run(t *testing.T) {
 	log := testlog.Logger(t, log.LvlTrace)
 	chainSource := NewFakeChainSource(tc.l1Chains, tc.l2Chains, log)
-	l1headsCh := make(chan eth.L1Node, 10)
+	l1headsCh := make(chan eth.L1BlockRef, 10)
 	// Unbuffered channels to force a sync point between
 	outputIn := make(chan outputArgs)
 	outputReturn := make(chan outputReturnArgs)

--- a/opnode/rollup/driver/state_test.go
+++ b/opnode/rollup/driver/state_test.go
@@ -1,139 +1,180 @@
 package driver
 
-// import (
-// 	"context"
-// 	"math/big"
-// 	"strconv"
-// 	"strings"
-// 	"testing"
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
 
-// 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
-// 	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testlog"
-// 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
-// 	"github.com/ethereum/go-ethereum/common"
-// 	"github.com/ethereum/go-ethereum/log"
-// 	"github.com/stretchr/testify/assert"
-// 	"github.com/stretchr/testify/mock"
-// )
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testlog"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+)
 
-// type testID string
+type testID string
 
-// func (id testID) ID() eth.BlockID {
-// 	parts := strings.Split(string(id), ":")
-// 	if len(parts) != 2 {
-// 		panic("bad id")
-// 	}
-// 	if len(parts[0]) > 32 {
-// 		panic("test ID hash too long")
-// 	}
-// 	var h common.Hash
-// 	copy(h[:], parts[0])
-// 	v, err := strconv.ParseUint(parts[1], 0, 64)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	return eth.BlockID{
-// 		Hash:   h,
-// 		Number: v,
-// 	}
-// }
+func (id testID) ID() eth.BlockID {
+	parts := strings.Split(string(id), ":")
+	if len(parts) != 2 {
+		panic("bad id")
+	}
+	if len(parts[0]) > 32 {
+		panic("test ID hash too long")
+	}
+	var h common.Hash
+	copy(h[:], parts[0])
+	v, err := strconv.ParseUint(parts[1], 0, 64)
+	if err != nil {
+		panic(err)
+	}
+	return eth.BlockID{
+		Hash:   h,
+		Number: v,
+	}
+}
 
-// type testState struct {
-// 	l1Head      testID
-// 	l1Base      testID
-// 	l2Head      testID
-// 	l2Finalized testID
+type outputHandlerFn func(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, l1Window []eth.BlockID) (eth.BlockID, error)
 
-// 	l1Window    []testID
-// 	l1WindowEnd testID
+func (fn outputHandlerFn) step(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, l1Window []eth.BlockID) (eth.BlockID, error) {
+	return fn(ctx, l2Head, l2Finalized, l1Window)
+}
 
-// 	genesisL1 testID
-// 	genesisL2 testID
+type outputArgs struct {
+	l2Head      eth.BlockID
+	l2Finalized eth.BlockID
+	l1Window    []eth.BlockID
+}
 
-// 	seqWindowSize uint64
-// }
+type outputReturnArgs struct {
+	l2Head eth.BlockID
+	err    error
+}
 
-// func makeState(st testState) *state {
-// 	window := make([]eth.BlockID, len(st.l1Window))
-// 	for i, id := range st.l1Window {
-// 		window[i] = id.ID()
-// 	}
-// 	return &state{
-// 		l1Head:      st.l1Head.ID(),
-// 		l2Head:      st.l2Head.ID(),
-// 		l2Finalized: st.l2Finalized.ID(),
-// 		l1Base:      st.l1Base.ID(),
-// 		l1Window:    window,
-// 		l1WindowEnd: st.l1WindowEnd.ID(),
-// 		// TODO: improve testing config (test different seq window sizes and non-zero L2 genesis time?)
-// 		Config: rollup.Config{
-// 			Genesis: rollup.Genesis{
-// 				L1:     st.genesisL1.ID(),
-// 				L2:     st.genesisL2.ID(),
-// 				L2Time: 0,
-// 			},
-// 			BlockTime:            2,
-// 			MaxSequencerTimeDiff: 10,
-// 			SeqWindowSize:        st.seqWindowSize,
-// 			L1ChainID:            big.NewInt(100),
-// 			FeeRecipientAddress:  common.Address{0x0a},
-// 			BatchInboxAddress:    common.Address{0x0b},
-// 			BatchSenderAddress:   common.Address{0x0c},
-// 		},
-// 	}
-// }
+type stateTestCaseStep struct {
+	expectedL1Head testID
+	expectedL2Head testID
+	expectedWindow []testID
 
-// type mockDriver struct {
-// 	mock.Mock
-// }
+	l1action  func(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1Node, reorgBase int)
+	l2action  func(t *testing.T, expectedWindow []testID, s *state, src *fakeChainSource, outputIn chan outputArgs, outputReturn chan outputReturnArgs)
+	reorgBase int
+}
 
-// func (m *mockDriver) requestEngineHead(ctx context.Context) (refL1 eth.BlockID, refL2 eth.BlockID, err error) {
-// 	returnArgs := m.Called(ctx)
-// 	refL1 = returnArgs.Get(0).(eth.BlockID)
-// 	refL2 = returnArgs.Get(1).(eth.BlockID)
-// 	err = returnArgs.Get(2).(error)
-// 	return
-// }
+func advanceL1(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1Node, reorgBase int) {
+	l1Heads <- src.advanceL1()
+}
 
-// func (m *mockDriver) findSyncStart(ctx context.Context) (nextL1s []eth.BlockID, refL2 eth.BlockID, err error) {
-// 	returnArgs := m.Called(ctx)
-// 	nextL1s = returnArgs.Get(0).([]eth.BlockID)
-// 	refL2 = returnArgs.Get(1).(eth.BlockID)
-// 	err, _ = returnArgs.Get(2).(error)
-// 	return
-// }
+func stutterL1(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1Node, reorgBase int) {
+	l1Heads <- src.l1Head()
+}
 
-// func (m *mockDriver) driverStep(ctx context.Context, seqWindow []eth.BlockID, refL2 eth.BlockID, finalized eth.BlockID) (l2ID eth.BlockID, err error) {
-// 	returnArgs := m.Called(ctx, seqWindow, refL2, finalized)
-// 	l2ID = returnArgs.Get(0).(eth.BlockID)
-// 	err, _ = returnArgs.Get(1).(error)
-// 	return
-// }
+func reorg__L1(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1Node, reorgBase int) {
+	src.reorgChains(reorgBase)
+	l1Heads <- src.l1Head()
+}
 
-// var _ internalDriver = (*mockDriver)(nil)
+func stutterL2(t *testing.T, expectedWindow []testID, s *state, src *fakeChainSource, outputIn chan outputArgs, outputReturn chan outputReturnArgs) {
+	select {
+	case <-outputIn:
+		t.Error("Got a step when no step should have occurred (l1 only advance)")
+	default:
+	}
+}
 
-// func TestEngineDriverState_RequestSync(t *testing.T) {
-// 	log := testlog.Logger(t, log.LvlTrace)
-// 	driver := new(mockDriver)
-// 	ctx := context.Background()
+func advanceL2(t *testing.T, expectedWindow []testID, s *state, src *fakeChainSource, outputIn chan outputArgs, outputReturn chan outputReturnArgs) {
+	args := <-outputIn
+	assert.Equal(t, int(s.Config.SeqWindowSize), len(args.l1Window), "Invalid L1 window size")
+	assert.Equal(t, len(expectedWindow), len(args.l1Window), "L1 Window size does not match expectedWindow")
+	for i := range expectedWindow {
+		assert.Equal(t, expectedWindow[i].ID(), args.l1Window[i], "Window elements must match")
+	}
+	outputReturn <- outputReturnArgs{l2Head: src.advanceL2().Self, err: nil}
+}
 
-// 	state := makeState(testState{
-// 		l1Head:        "e:4",
-// 		l1Base:        "c:2",
-// 		l2Head:        "C:2",
-// 		l2Finalized:   "B:1",
-// 		l1Window:      []testID{"d:3", "e:4", "c:5"}, // TODO: multiple batches per L1 block
-// 		l1WindowEnd:   "c:5",
-// 		genesisL1:     "a:0",
-// 		genesisL2:     "b:0",
-// 		seqWindowSize: 1, // TODO: test larger sequencing sizes (requires updating test below)
-// 	})
-// 	driver.On("findSyncStart", ctx).Return([]eth.BlockID{testID("d:3").ID()}, testID("C:2").ID(), nil)
-// 	driver.On("driverStep", ctx, []eth.BlockID{testID("d:3").ID()}, testID("C:2").ID(), testID("B:1").ID()).Return(testID("D:3").ID(), nil)
+type stateTestCase struct {
+	name      string
+	l1Chains  []string
+	l2Chains  []string
+	steps     []stateTestCaseStep
+	seqWindow int
+}
 
-// 	l2Updated := state.requestSync(ctx, log, driver)
+func (tc *stateTestCase) Run(t *testing.T) {
+	log := testlog.Logger(t, log.LvlTrace)
+	chainSource := NewFakeChainSource(tc.l1Chains, tc.l2Chains, log)
+	l1headsCh := make(chan eth.L1Node, 10)
+	outputIn := make(chan outputArgs, 10)
+	outputReturn := make(chan outputReturnArgs, 10)
+	outputHandler := func(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, l1Window []eth.BlockID) (eth.BlockID, error) {
+		outputIn <- outputArgs{l2Head: l2Head, l2Finalized: l2Finalized, l1Window: l1Window}
+		r := <-outputReturn
+		return r.l2Head, r.err
+	}
+	config := rollup.Config{SeqWindowSize: uint64(tc.seqWindow)}
+	state := NewState(log, config, &inputImpl{chainSource: chainSource}, outputHandlerFn(outputHandler))
+	defer func() {
+		assert.NoError(t, state.Close(), "Error closing state")
+	}()
 
-// 	assert.Equal(t, state.l1Head, testID("d:3").ID())
-// 	assert.Equal(t, state.l2Head, testID("D:3").ID())
-// 	assert.True(t, l2Updated)
-// }
+	err := state.Start(context.Background(), l1headsCh)
+	assert.NoError(t, err, "Error starting the state object")
+
+	for _, step := range tc.steps {
+		step.l1action(t, state, chainSource, l1headsCh, step.reorgBase)
+		<-time.After(5 * time.Millisecond)
+		step.l2action(t, step.expectedWindow, state, chainSource, outputIn, outputReturn)
+		<-time.After(5 * time.Millisecond)
+
+		assert.Equal(t, step.expectedL1Head.ID(), state.l1Head, "l1 head")
+		assert.Equal(t, step.expectedL2Head.ID(), state.l2Head, "l2 head")
+	}
+}
+
+func TestDriver(t *testing.T) {
+	cases := []stateTestCase{
+		{
+			name:      "Simple extensions",
+			l1Chains:  []string{"abcdefgh"},
+			l2Chains:  []string{"ABCDEF"},
+			seqWindow: 2,
+			steps: []stateTestCaseStep{
+				{l1action: stutterL1, l2action: stutterL2, expectedL1Head: "a:0", expectedL2Head: "A:0"},
+				{l1action: advanceL1, l2action: stutterL2, expectedL1Head: "b:1", expectedL2Head: "A:0", expectedWindow: []testID{"a:0", "b:1"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "c:2", expectedL2Head: "B:1", expectedWindow: []testID{"b:1", "c:2"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "d:3", expectedL2Head: "C:2", expectedWindow: []testID{"c:2", "d:3"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "e:4", expectedL2Head: "D:3", expectedWindow: []testID{"d:3", "e:4"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "f:5", expectedL2Head: "E:4", expectedWindow: []testID{"e:4", "f:5"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "g:6", expectedL2Head: "F:5", expectedWindow: []testID{"f:5", "g:6"}},
+			},
+		},
+		{
+			name:      "Include re-org",
+			l1Chains:  []string{"abcdefg", "abcxyzw"},
+			l2Chains:  []string{"ABCDEF", "ABCXYZ"},
+			seqWindow: 2,
+			steps: []stateTestCaseStep{
+				{l1action: stutterL1, l2action: stutterL2, expectedL1Head: "a:0", expectedL2Head: "A:0"},
+				{l1action: advanceL1, l2action: stutterL2, expectedL1Head: "b:1", expectedL2Head: "A:0", expectedWindow: []testID{"a:0", "b:1"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "c:2", expectedL2Head: "B:1", expectedWindow: []testID{"b:1", "c:2"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "d:3", expectedL2Head: "C:2", expectedWindow: []testID{"c:2", "d:3"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "e:4", expectedL2Head: "D:3", expectedWindow: []testID{"d:3", "e:4"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "f:5", expectedL2Head: "E:4", expectedWindow: []testID{"e:4", "f:5"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "g:6", expectedL2Head: "F:5", expectedWindow: []testID{"f:5", "g:6"}},
+				{l1action: reorg__L1, l2action: advanceL2, expectedL1Head: "w:6", expectedL2Head: "X:3", expectedWindow: []testID{"x:3", "y:4"}, reorgBase: 2},
+				{l1action: stutterL1, l2action: advanceL2, expectedL1Head: "w:6", expectedL2Head: "Y:4", expectedWindow: []testID{"y:4", "z:5"}},
+				{l1action: stutterL1, l2action: advanceL2, expectedL1Head: "w:6", expectedL2Head: "Z:5", expectedWindow: []testID{"z:5", "w:6"}},
+				{l1action: stutterL1, l2action: stutterL2, expectedL1Head: "w:6", expectedL2Head: "Z:5", expectedWindow: []testID{"z:5", "w:6"}},
+				{l1action: stutterL1, l2action: stutterL2, expectedL1Head: "w:6", expectedL2Head: "Z:5", expectedWindow: []testID{"z:5", "w:6"}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, tc.Run)
+	}
+
+}

--- a/opnode/rollup/driver/state_test.go
+++ b/opnode/rollup/driver/state_test.go
@@ -72,6 +72,16 @@ func stutterL1(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1
 	l1Heads <- src.l1Head()
 }
 
+func stutterAdvance(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1Node, reorgBase int) {
+	l1Heads <- src.l1Head()
+	l1Heads <- src.l1Head()
+	l1Heads <- src.l1Head()
+	l1Heads <- src.advanceL1()
+	l1Heads <- src.l1Head()
+	l1Heads <- src.l1Head()
+	l1Heads <- src.l1Head()
+}
+
 func reorg__L1(t *testing.T, s *state, src *fakeChainSource, l1Heads chan eth.L1Node, reorgBase int) {
 	src.reorgChains(reorgBase)
 	l1Heads <- src.l1Head()
@@ -169,6 +179,21 @@ func TestDriver(t *testing.T) {
 				{l1action: stutterL1, l2action: advanceL2, expectedL1Head: "w:6", expectedL2Head: "Z:5", expectedWindow: []testID{"z:5", "w:6"}},
 				{l1action: stutterL1, l2action: stutterL2, expectedL1Head: "w:6", expectedL2Head: "Z:5", expectedWindow: []testID{"z:5", "w:6"}},
 				{l1action: stutterL1, l2action: stutterL2, expectedL1Head: "w:6", expectedL2Head: "Z:5", expectedWindow: []testID{"z:5", "w:6"}},
+			},
+		},
+		{
+			name:      "Simple extensions with multi-step",
+			l1Chains:  []string{"abcdefgh"},
+			l2Chains:  []string{"ABCDEF"},
+			seqWindow: 2,
+			steps: []stateTestCaseStep{
+				{l1action: stutterL1, l2action: stutterL2, expectedL1Head: "a:0", expectedL2Head: "A:0"},
+				{l1action: advanceL1, l2action: stutterL2, expectedL1Head: "b:1", expectedL2Head: "A:0", expectedWindow: []testID{"a:0", "b:1"}},
+				{l1action: stutterAdvance, l2action: advanceL2, expectedL1Head: "c:2", expectedL2Head: "B:1", expectedWindow: []testID{"b:1", "c:2"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "d:3", expectedL2Head: "C:2", expectedWindow: []testID{"c:2", "d:3"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "e:4", expectedL2Head: "D:3", expectedWindow: []testID{"d:3", "e:4"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "f:5", expectedL2Head: "E:4", expectedWindow: []testID{"e:4", "f:5"}},
+				{l1action: advanceL1, l2action: advanceL2, expectedL1Head: "g:6", expectedL2Head: "F:5", expectedWindow: []testID{"f:5", "g:6"}},
 			},
 		},
 	}

--- a/opnode/rollup/driver/state_test.go
+++ b/opnode/rollup/driver/state_test.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"math/big"
 	"strconv"
 	"strings"
 	"testing"
@@ -42,8 +43,14 @@ type testState struct {
 	l2Head      testID
 	l2Finalized testID
 	l1Target    testID
-	genesisL1   testID
-	genesisL2   testID
+
+	l1Next       []testID
+	l2NextParent testID
+
+	genesisL1 testID
+	genesisL2 testID
+
+	seqWindowSize uint64
 }
 
 func makeState(st testState) *state {
@@ -52,9 +59,20 @@ func makeState(st testState) *state {
 		l2Head:      st.l2Head.ID(),
 		l2Finalized: st.l2Finalized.ID(),
 		l1Target:    st.l1Target.ID(),
-		Genesis: rollup.Genesis{
-			L1: st.genesisL1.ID(),
-			L2: st.genesisL2.ID(),
+		// TODO: improve testing config (test different seq window sizes and non-zero L2 genesis time?)
+		Config: rollup.Config{
+			Genesis: rollup.Genesis{
+				L1:     st.genesisL1.ID(),
+				L2:     st.genesisL2.ID(),
+				L2Time: 0,
+			},
+			BlockTime:            2,
+			MaxSequencerTimeDiff: 10,
+			SeqWindowSize:        st.seqWindowSize,
+			L1ChainID:            big.NewInt(100),
+			FeeRecipientAddress:  common.Address{0x0a},
+			BatchInboxAddress:    common.Address{0x0b},
+			BatchSenderAddress:   common.Address{0x0c},
 		},
 	}
 }

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -108,7 +108,7 @@ func AddBlock(ctx context.Context, logger log.Logger, rpc DriverAPI,
 	}
 
 	logger = logger.New("derived_l2", payload.ID())
-	logger.Info("derived full block")
+	logger.Info("derived full block", "l2Parent", l2Parent, "attrs", attrs, "payload", payload)
 
 	err = l2.ExecutePayload(ctx, rpc, payload)
 	if err != nil {

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -7,9 +7,12 @@ import (
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/l2"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup/derive"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type DriverAPI interface {
@@ -17,43 +20,95 @@ type DriverAPI interface {
 	l2.EthBackend
 }
 
-// step takes an L1 block id and then creates and executes the L2 block. The forkchoice is updated as well.
-func (d *Driver) step(ctx context.Context, l1Input eth.BlockID, l2Parent eth.BlockID, l2Finalized common.Hash) (eth.BlockID, error) {
-	logger := d.log.New("input_l1", l1Input, "input_l2_parent", l2Parent, "finalized_l2", l2Finalized)
+type Downloader interface {
+	// FetchL1Info fetches the L1 header information corresponding to a L1 block ID
+	FetchL1Info(ctx context.Context, id eth.BlockID) (derive.L1Info, error)
+	// FetchReceipts of a L1 block
+	FetchReceipts(ctx context.Context, id eth.BlockID) ([]*types.Receipt, error)
+	// FetchBatches from the given window of L1 blocks
+	FetchBatches(ctx context.Context, window []eth.BlockID) ([]derive.BatchData, error)
+	// FetchL2Info fetches the L2 header information corresponding to a L2 block ID
+	FetchL2Info(ctx context.Context, id eth.BlockID) (derive.L2Info, error)
+}
+
+// DriverStep derives and processes one or more L2 blocks from the given sequencing window of L1 blocks.
+// An incomplete sequencing window will result in an incomplete L2 chain if so.
+//
+// After the step completes it returns the block ID of the last processed L2 block, even if an error occurs.
+func (d *Driver) step(ctx context.Context, l1Input []eth.BlockID, l2Parent eth.BlockID, l2Finalized common.Hash) (out eth.BlockID, err error) {
+
+	if len(l1Input) == 0 {
+		return l2Parent, fmt.Errorf("empty L1 sequencing window on L2 %s", l2Parent)
+	}
+
+	logger := d.log.New("input_l1_first", l1Input[0], "input_l1_last", l1Input[len(l1Input)-1],
+		"input_l2_parent", l2Parent, "finalized_l2", l2Finalized)
+
+	epoch := rollup.Epoch(l1Input[0].Number)
 
 	fetchCtx, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
-	bl, receipts, err := d.dl.Fetch(fetchCtx, l1Input)
-	if err != nil {
-		return eth.BlockID{}, fmt.Errorf("failed to fetch block with receipts: %v", err)
-	}
-	logger.Debug("fetched L1 data for driver")
 
-	attrs, err := derive.PayloadAttributes(bl, receipts)
+	l2Info, err := d.dl.FetchL2Info(fetchCtx, l2Parent)
 	if err != nil {
-		return eth.BlockID{}, fmt.Errorf("failed to derive execution payload inputs: %v", err)
+		return l2Parent, fmt.Errorf("failed to fetch L2 block info of %s: %v", l2Parent, err)
+	}
+	l1Info, err := d.dl.FetchL1Info(fetchCtx, l1Input[0])
+	if err != nil {
+		return l2Parent, fmt.Errorf("failed to fetch L1 block info of %s: %v", l1Input[0], err)
+	}
+	receipts, err := d.dl.FetchReceipts(fetchCtx, l1Input[0])
+	if err != nil {
+		return l2Parent, fmt.Errorf("failed to fetch receipts of %s: %v", l1Input[0], err)
+	}
+	// TODO: with sharding the blobs may be identified in more detail than L1 block hashes
+	batches, err := d.dl.FetchBatches(fetchCtx, l1Input)
+	if err != nil {
+		return l2Parent, fmt.Errorf("failed to fetch batches from %s: %v", l1Input, err)
+	}
+
+	attrsList, err := derive.PayloadAttributes(&d.Config, l1Info, receipts, batches, l2Info)
+	if err != nil {
+		return l2Parent, fmt.Errorf("failed to derive execution payload inputs: %v", err)
 	}
 	logger.Debug("derived L2 block inputs")
 
-	payload, err := derive.ExecutionPayload(ctx, d.rpc, l2Parent.Hash, l2Finalized, attrs)
+	last := l2Parent
+	for i, attrs := range attrsList {
+		last, err := AddBlock(ctx, logger, d.rpc, last, l2Finalized, attrs)
+		if err != nil {
+			return last, fmt.Errorf("failed to extend L2 chain at block %d/%d of epoch %d: %v", i, len(attrsList), epoch, err)
+		}
+	}
+
+	return last, nil
+}
+
+// AddBlock extends the L2 chain by deriving the full execution payload from inputs,
+// and then executing and persisting it.
+//
+// After the step completes it returns the block ID of the last processed L2 block, even if an error occurs.
+func AddBlock(ctx context.Context, logger log.Logger, rpc DriverAPI,
+	l2Parent eth.BlockID, l2Finalized common.Hash, attrs *l2.PayloadAttributes) (eth.BlockID, error) {
+
+	payload, err := derive.ExecutionPayload(ctx, rpc, l2Parent.Hash, l2Finalized, attrs)
 	if err != nil {
-		return eth.BlockID{}, fmt.Errorf("failed to derive execution payload: %v", err)
+		return l2Parent, fmt.Errorf("failed to derive execution payload: %v", err)
 	}
 
 	logger = logger.New("derived_l2", payload.ID())
 	logger.Info("derived full block")
 
-	err = l2.ExecutePayload(ctx, d.rpc, payload)
+	err = l2.ExecutePayload(ctx, rpc, payload)
 	if err != nil {
-		return eth.BlockID{}, fmt.Errorf("failed to apply execution payload: %v", err)
+		return l2Parent, fmt.Errorf("failed to apply execution payload: %v", err)
 	}
 	logger.Info("executed block")
 
-	err = l2.ForkchoiceUpdate(ctx, d.rpc, payload.BlockHash, l2Finalized)
+	err = l2.ForkchoiceUpdate(ctx, rpc, payload.BlockHash, l2Finalized)
 	if err != nil {
-		return eth.BlockID{}, fmt.Errorf("failed to persist execution payload: %v", err)
+		return payload.ID(), fmt.Errorf("failed to persist execution payload: %v", err)
 	}
 	logger.Info("updated fork-choice with block")
-
 	return payload.ID(), nil
 }

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -86,7 +86,7 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized e
 
 	last := l2Head
 	for i, attrs := range attrsList {
-		last, err := AddBlock(ctx, logger, d.rpc, last, l2Finalized.Hash, attrs)
+		last, err = AddBlock(ctx, logger, d.rpc, last, l2Finalized.Hash, attrs)
 		if err != nil {
 			return last, fmt.Errorf("failed to extend L2 chain at block %d/%d of epoch %d: %v", i, len(attrsList), epoch, err)
 		}

--- a/opnode/rollup/sync/reference.go
+++ b/opnode/rollup/sync/reference.go
@@ -26,10 +26,10 @@ type L2Client interface {
 
 // ChainSource provides access to the L1 and L2 block graph
 type ChainSource interface {
-	L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error)
-	L1HeadNode(ctx context.Context) (eth.L1BlockRef, error)
-	L2NodeByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error)
-	L2NodeByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error)
+	L1BlockRefByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error)
+	L1HeadBlockRef(ctx context.Context) (eth.L1BlockRef, error)
+	L2BlockRefByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error)
+	L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error)
 }
 
 func NewChainSource(l1 L1Client, l2 L2Client, genesis *rollup.Genesis) *chainSourceImpl {
@@ -42,19 +42,19 @@ type chainSourceImpl struct {
 	genesis *rollup.Genesis
 }
 
-// L1NodeByNumber returns the canonical block and parent ids.
-func (src chainSourceImpl) L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error) {
-	return src.l1NodeByNumber(ctx, new(big.Int).SetUint64(l1Num))
+// L1BlockRefByNumber returns the canonical block and parent ids.
+func (src chainSourceImpl) L1BlockRefByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error) {
+	return src.l1BlockRefByNumber(ctx, new(big.Int).SetUint64(l1Num))
 }
 
-// L1NodeByNumber returns the canonical head block and parent ids.
-func (src chainSourceImpl) L1HeadNode(ctx context.Context) (eth.L1BlockRef, error) {
-	return src.l1NodeByNumber(ctx, nil)
+// L1BlockRefByNumber returns the canonical head block and parent ids.
+func (src chainSourceImpl) L1HeadBlockRef(ctx context.Context) (eth.L1BlockRef, error) {
+	return src.l1BlockRefByNumber(ctx, nil)
 }
 
-// l1NodeByNumber wraps l1.HeaderByNumber to return an eth.L1Node
-// This is internal because the exposed L1NodeByNumber takes uint64 instead of big.Ints
-func (src chainSourceImpl) l1NodeByNumber(ctx context.Context, number *big.Int) (eth.L1BlockRef, error) {
+// l1BlockRefByNumber wraps l1.HeaderByNumber to return an eth.L1BlockRef
+// This is internal because the exposed L1BlockRefByNumber takes uint64 instead of big.Ints
+func (src chainSourceImpl) l1BlockRefByNumber(ctx context.Context, number *big.Int) (eth.L1BlockRef, error) {
 	header, err := src.l1.HeaderByNumber(ctx, number)
 	if err != nil {
 		// w%: wrap the error, we still need to detect if a canonical block is not found, a.k.a. end of chain.
@@ -71,8 +71,8 @@ func (src chainSourceImpl) l1NodeByNumber(ctx context.Context, number *big.Int) 
 	}, nil
 }
 
-// L2NodeByNumber returns the canonical block and parent ids.
-func (src chainSourceImpl) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
+// L2BlockRefByNumber returns the canonical block and parent ids.
+func (src chainSourceImpl) L2BlockRefByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
 	block, err := src.l2.BlockByNumber(ctx, l2Num)
 	if err != nil {
 		// w%: wrap the error, we still need to detect if a canonical block is not found, a.k.a. end of chain.
@@ -81,8 +81,8 @@ func (src chainSourceImpl) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (
 	return derive.BlockReferences(block, src.genesis)
 }
 
-// L2NodeByHash returns the block & parent ids based on the supplied hash. The returned node may not be in the canonical chain
-func (src chainSourceImpl) L2NodeByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
+// L2BlockRefByHash returns the block & parent ids based on the supplied hash. The returned BlockRef may not be in the canonical chain
+func (src chainSourceImpl) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
 	block, err := src.l2.BlockByHash(ctx, l2Hash)
 	if err != nil {
 		// w%: wrap the error, we still need to detect if a canonical block is not found, a.k.a. end of chain.

--- a/opnode/rollup/sync/start.go
+++ b/opnode/rollup/sync/start.go
@@ -137,6 +137,10 @@ func FindL1Range(ctx context.Context, source ChainSource, begin eth.BlockID) ([]
 		maxBlocks = l1head.Self.Number - begin.Number
 	}
 
+	if maxBlocks == 0 {
+		return nil, nil
+	}
+
 	prevHash := begin.Hash
 	var res []eth.BlockID
 	for i := begin.Number + 1; i < begin.Number+maxBlocks+1; i++ {

--- a/opnode/rollup/sync/start_test.go
+++ b/opnode/rollup/sync/start_test.go
@@ -17,14 +17,14 @@ type fakeChainSource struct {
 	L2 []eth.L2BlockRef
 }
 
-func (m *fakeChainSource) L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error) {
+func (m *fakeChainSource) L1BlockRefByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error) {
 	if l1Num >= uint64(len(m.L1)) {
 		return eth.L1BlockRef{}, ethereum.NotFound
 	}
 	return m.L1[l1Num], nil
 }
 
-func (m *fakeChainSource) L1HeadNode(ctx context.Context) (eth.L1BlockRef, error) {
+func (m *fakeChainSource) L1HeadBlockRef(ctx context.Context) (eth.L1BlockRef, error) {
 	l := len(m.L1)
 	if l == 0 {
 		return eth.L1BlockRef{}, ethereum.NotFound
@@ -32,7 +32,7 @@ func (m *fakeChainSource) L1HeadNode(ctx context.Context) (eth.L1BlockRef, error
 	return m.L1[l-1], nil
 }
 
-func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
+func (m *fakeChainSource) L2BlockRefByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
 	if len(m.L2) == 0 {
 		panic("bad test, no l2 chain")
 	}
@@ -43,10 +43,10 @@ func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (e
 	return m.L2[i], nil
 }
 
-func (m *fakeChainSource) L2NodeByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
+func (m *fakeChainSource) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
 	for i, bl := range m.L2 {
 		if bl.Self.Hash == l2Hash {
-			return m.L2NodeByNumber(ctx, big.NewInt(int64(i)))
+			return m.L2BlockRefByNumber(ctx, big.NewInt(int64(i)))
 		}
 	}
 	return eth.L2BlockRef{}, ethereum.NotFound

--- a/opnode/rollup/sync/start_test.go
+++ b/opnode/rollup/sync/start_test.go
@@ -13,26 +13,26 @@ import (
 )
 
 type fakeChainSource struct {
-	L1 []eth.L1Node
-	L2 []eth.L2Node
+	L1 []eth.L1BlockRef
+	L2 []eth.L2BlockRef
 }
 
-func (m *fakeChainSource) L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1Node, error) {
+func (m *fakeChainSource) L1NodeByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error) {
 	if l1Num >= uint64(len(m.L1)) {
-		return eth.L1Node{}, ethereum.NotFound
+		return eth.L1BlockRef{}, ethereum.NotFound
 	}
 	return m.L1[l1Num], nil
 }
 
-func (m *fakeChainSource) L1HeadNode(ctx context.Context) (eth.L1Node, error) {
+func (m *fakeChainSource) L1HeadNode(ctx context.Context) (eth.L1BlockRef, error) {
 	l := len(m.L1)
 	if l == 0 {
-		return eth.L1Node{}, ethereum.NotFound
+		return eth.L1BlockRef{}, ethereum.NotFound
 	}
 	return m.L1[l-1], nil
 }
 
-func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (eth.L2Node, error) {
+func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
 	if len(m.L2) == 0 {
 		panic("bad test, no l2 chain")
 	}
@@ -43,13 +43,13 @@ func (m *fakeChainSource) L2NodeByNumber(ctx context.Context, l2Num *big.Int) (e
 	return m.L2[i], nil
 }
 
-func (m *fakeChainSource) L2NodeByHash(ctx context.Context, l2Hash common.Hash) (eth.L2Node, error) {
+func (m *fakeChainSource) L2NodeByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
 	for i, bl := range m.L2 {
 		if bl.Self.Hash == l2Hash {
 			return m.L2NodeByNumber(ctx, big.NewInt(int64(i)))
 		}
 	}
-	return eth.L2Node{}, ethereum.NotFound
+	return eth.L2BlockRef{}, ethereum.NotFound
 }
 
 var _ ChainSource = (*fakeChainSource)(nil)
@@ -60,23 +60,23 @@ func fakeID(id rune, num uint64) eth.BlockID {
 	return eth.BlockID{Hash: h, Number: uint64(num)}
 }
 
-func fakeL1Block(self rune, parent rune, num uint64) eth.L1Node {
+func fakeL1Block(self rune, parent rune, num uint64) eth.L1BlockRef {
 	var parentID eth.BlockID
 	if num != 0 {
 		parentID = fakeID(parent, num-1)
 	}
-	return eth.L1Node{Self: fakeID(self, num), Parent: parentID}
+	return eth.L1BlockRef{Self: fakeID(self, num), Parent: parentID}
 }
 
-func fakeL2Block(self rune, parent rune, l1parent eth.BlockID, num uint64) eth.L2Node {
+func fakeL2Block(self rune, parent rune, l1parent eth.BlockID, num uint64) eth.L2BlockRef {
 	var parentID eth.BlockID
 	if num != 0 {
 		parentID = fakeID(parent, num-1)
 	}
-	return eth.L2Node{Self: fakeID(self, num), L2Parent: parentID, L1Parent: l1parent}
+	return eth.L2BlockRef{Self: fakeID(self, num), Parent: parentID, L1Origin: l1parent}
 }
 
-func chainL1(offset uint64, ids string) (out []eth.L1Node) {
+func chainL1(offset uint64, ids string) (out []eth.L1BlockRef) {
 	var prevID rune
 	for i, id := range ids {
 		out = append(out, fakeL1Block(id, prevID, offset+uint64(i)))
@@ -85,7 +85,7 @@ func chainL1(offset uint64, ids string) (out []eth.L1Node) {
 	return
 }
 
-func chainL2(l1 []eth.L1Node, ids string) (out []eth.L2Node) {
+func chainL2(l1 []eth.L1BlockRef, ids string) (out []eth.L2BlockRef) {
 	var prevID rune
 	for i, id := range ids {
 		out = append(out, fakeL2Block(id, prevID, l1[i].Self, uint64(i)))

--- a/opnode/rollup/types.go
+++ b/opnode/rollup/types.go
@@ -1,8 +1,48 @@
 package rollup
 
-import "github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
 
 type Genesis struct {
+	// The L1 block that the rollup starts *after* (no derived transactions)
 	L1 eth.BlockID
+	// The L2 block the rollup starts from (no transactions, pre-configured state)
 	L2 eth.BlockID
+	// Timestamp of L2 block
+	L2Time uint64
 }
+
+type Config struct {
+	// Genesis anchor point of the rollup
+	Genesis Genesis
+	// Seconds per L2 block
+	BlockTime uint64
+	// Sequencer batches may not be more than MaxSequencerTimeDiff seconds after
+	// the L1 timestamp of the sequencing window end.
+	//
+	// Note: When L1 has many 1 second consecutive blocks, and L2 grows at fixed 2 seconds,
+	// the L2 time may still grow beyond this difference.
+	MaxSequencerTimeDiff uint64
+	// Number of epochs (L1 blocks) per sequencing window
+	SeqWindowSize uint64
+	// Required to verify L1 signatures
+	L1ChainID *big.Int
+
+	// L2 address receiving all L2 transaction fees
+	FeeRecipientAddress common.Address
+	// L1 address that batches are sent to
+	BatchInboxAddress common.Address
+	// Acceptable batch-sender address
+	BatchSenderAddress common.Address
+}
+
+func (c *Config) L1Signer() types.Signer {
+	return types.NewLondonSigner(c.L1ChainID)
+}
+
+type Epoch uint64

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimistic-specs/opnode/contracts/deposit"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testlog"
 	rollupNode "github.com/ethereum-optimism/optimistic-specs/opnode/node"
-	"github.com/stretchr/testify/require"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
+	"github.com/stretchr/testify/require"
 )
 
 func getGenesisHash(client *ethclient.Client) common.Hash {
@@ -120,7 +121,18 @@ func TestSystemE2E(t *testing.T) {
 		L1Num:         0,
 		L1NodeAddr:    endpoint(cfg.l1.nodeConfig),
 		L2EngineAddrs: []string{endpoint(cfg.l2.nodeConfig)},
+		Rollup: rollup.Config{
+			BlockTime:            1,
+			MaxSequencerTimeDiff: 10,
+			SeqWindowSize:        1,
+			L1ChainID:            big.NewInt(901),
+			// TODO pick defaults
+			FeeRecipientAddress: common.Address{0xff, 0x01},
+			BatchInboxAddress:   common.Address{0xff, 0x02},
+			BatchSenderAddress:  common.Address{0xff, 0x03},
+		},
 	}
+	nodeCfg.Rollup.Genesis = nodeCfg.GetGenesis()
 	node, err := rollupNode.New(context.Background(), nodeCfg, testlog.Logger(t, log.LvlTrace))
 	require.Nil(t, err)
 

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -248,7 +248,7 @@ func TestSystemE2E(t *testing.T) {
 	require.Nil(t, err, "Could not get transaction receipt")
 
 	// Wait (or timeout) for that block to show up on L2
-	timeoutCh := time.After(3 * time.Second)
+	timeoutCh := time.After(6 * time.Second)
 loop:
 	for {
 		select {


### PR DESCRIPTION
**Description**

This PR enables verifiers to use submitted batches to construct the L2 chain. It updates two areas: block derivation and the rollup driver.

This updates the block-derivation to:
* Take a sequencing window as input
* Check the size and consistency of the input
* Derive L2 payloads from possibly out-of-order batches (ignore past/future epochs with overlapping sequencing window)
* Build L2 blocks with fixed block time (fill gaps with empty blocks)
* Limit L2 sequencer-produced blocks to a time-window, do not fill ridiculous out-of-window gaps with empty L2 blocks (by accident or not)
* Force deposits of the epoch (first L1 block of window) into the batch of the first L2 time slot (created if none exists)


This updates the rollup driver:
* Split the rollup driver into `state` and `step`.
* The `state` object maintains a view of the L1 and L2 chains and is responsible for producing sequencing windows based on new L1 blocks or L1/L2 re-orgs.
* The `step` function takes the sequence window (list of block number / hashes) then fetches data from L1, turns that into L2 blocks, and then executes L2 blocks.
* Adds a new `fakeChainSource` to test the rollup driver
* Refactors the rollup driver loop and handling code to look at sequencing windows instead of a single block at a time.


**Metadata**
- Fixes #150 
- Fixes #149 
- Fixes #189
- Fixes #185
- Fixes ENG-2013
- Fixes ENG-2014