### PR TITLE
Initial sequencing spec

### DIFF
--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -77,10 +77,9 @@ for a variable-length encoding scheme.
 Although we define only one new transaction type, we can distinguish between two kinds of deposited
 transactions, based on their positioning in the L2 block:
 
-1. The first transaction MUST be a [L1 attributes deposited transaction][l1-attr-deposit], followed
-   by
+1. The first transaction MUST be a [L1 attributes deposited transaction][l1-attr-deposit], followed by
 2. an array of zero-or-more [user-deposited transactions][user-deposited] submitted to the deposit
-   feed contract on L1.
+   feed contract on L1. User-deposited transactions are only present in the first block of a L2 epoch.
 
 We only define a single new transaction type in order to minimize modifications to L1 client
 software, and complexity in general.

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -7,7 +7,6 @@
 [g-deposits]: glossary.md#deposits
 [g-l1-attr-deposit]: glossary.md#l1-attributes-deposited-transaction
 [g-user-deposited]: glossary.md#user-deposited-transaction
-[g-deposit-block]: glossary.md#deposit-block
 [g-eoa]: glossary.md#eoa
 
 [Deposited transactions][g-deposited], also known as [deposits][g-deposits] are transactions which
@@ -76,7 +75,7 @@ for a variable-length encoding scheme.
 ### Kinds of Deposited Transactions
 
 Although we define only one new transaction type, we can distinguish between two kinds of deposited
-transactions, based on their positioning in the [deposit block][g-deposit-block]:
+transactions, based on their positioning in the L2 block:
 
 1. The first transaction MUST be a [L1 attributes deposited transaction][l1-attr-deposit], followed
    by

--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -15,9 +15,12 @@
   - [Receipt](#receipt)
   - [Transaction Type](#transaction-type)
   - [Fork Choice Rule](#fork-choice-rule)
+- [Sequencing](#sequencing)
+  - [Sequencing window](#sequencing-window)
+  - [Sequencing epoch](#sequencing-epoch)
+  - [Sequencer batch](#sequencer-batch)
 - [Deposits](#deposits)
   - [Deposited Transaction](#deposited-transaction)
-  - [Deposit Block](#deposit-block)
   - [L1 Attributes Deposited Transaction](#l1-attributes-deposited-transaction)
   - [User-Deposited Transaction](#user-deposited-transaction)
   - [Depositing Call](#depositing-call)
@@ -140,6 +143,38 @@ on-chain-confirmed head, or the on-chain-finalized head.
 
 ------------------------------------------------------------------------------------------------------------------------
 
+# Sequencing
+
+[sequencing]: glossary.md#sequencing
+
+Transactions in the rollup can be included in two ways:
+
+- Through a [deposited transaction](#deposited-transaction), enforced by the system
+- Through a regular transaction, embedded in a [sequencer batch](#sequencer-batch)
+
+Submitting transactions for inclusion in a batch saves costs by reducing overhead, and enables the sequencer to
+pre-confirm the transactions before the L1 confirms the data.
+
+## Sequencing window
+
+[sequencing-window]: glossary.md#sequencing-window
+
+A sequencing window is a range of L1 blocks, to parse inputs from during a derivation step.
+
+## Sequencing epoch
+
+A sequencing epoch is a number identifying the start of a [sequencing window](#sequencing-window),
+equal to the L1 block number of the first block in the window.
+
+## Sequencer batch
+
+[sequencer-batch]: glossary.md#sequencer-batch
+
+A sequencer batch is list of L2 transactions tagged with an [`epoch`](#sequencing-epoch) and L2 block `timestamp`.
+Each L2 block can have one batch of transactions, an input for the block derivation.
+
+------------------------------------------------------------------------------------------------------------------------
+
 # Deposits
 
 [deposits]: glossary.md#deposits
@@ -170,8 +205,7 @@ Deposits are specified in the [deposits specification][deposits-spec].
 
 [deposited]: glossary.md#deposited-transaction
 
-A *deposited transaction* is a L2 transaction that was derived from L1 and is included in a [deposit
-block][deposit-block].
+A *deposited transaction* is a L2 transaction that was derived from L1 and included in a L2 block.
 
 There are two kinds of deposited transactions:
 
@@ -181,12 +215,6 @@ There are two kinds of deposited transactions:
   contract][deposit-contract].
 
 [deposits-spec]: deposits.md
-
-## Deposit Block
-
-[deposit-block]: glossary.md#deposit-block
-
-A *deposit block* is a L2 block that contains only [deposited transactions][deposited].
 
 ## L1 Attributes Deposited Transaction
 
@@ -312,6 +340,7 @@ L2 derivation inputs include:
   - timestamp
   - basefee
 - [deposits] (as log data)
+- [sequencer batches][sequencer-batch] (as transaction data)
 
 ## Payload Attributes
 

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -167,6 +167,8 @@ entries.
 [deposit-contract-spec]: deposits.md#deposit-contract
 
 Each of the derived `PayloadAttributes` starts with a L1 Attributes transaction.
+Like other derived deposits, this does not have to be batch-submitted, and exposes the required L1 information for the
+process of finding the sync starting point of the L2 chain, without requiring L2 state access.
 
 The [User-deposited] transactions are all put in the first of the derived `PayloadAttributes`,
 inserted after the L1 Attributes transaction, before any [sequenced][g-sequencing] transactions.

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -128,6 +128,7 @@ The rollup reads the following data from the [sequencing window][g-sequencing-wi
       - `min_l2_timestamp < batch.timestamp < max_l2_timestamp`, i.e. timestamp is within range
       - The batch is the first batch with `batch.timestamp` in this sequencing window,
         i.e. one batch per L2 block number
+      - The batch only contains sequenced transactions, i.e. it must NOT contain any Deposit-type transactions.
 
 [random]: https://eips.ethereum.org/EIPS/eip-4399
 
@@ -149,7 +150,7 @@ Batch contents:
 
 - `epoch` is the sequencing window epoch, i.e. the first L1 block number
 - `timestamp` is the L2 timestamp of the block
-- `transaction_list` is an RLP encoded list of [EIP-2718] encoded transactions
+- `transaction_list` is an RLP encoded list of [EIP-2718] encoded transactions.
 
 [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 
@@ -207,7 +208,8 @@ The object's properties must be set as follows:
 - `timestamp` is set to the timestamp of the L1 block.
 - `random` is set to the *random* L1 block attribute
 - `suggestedFeeRecipient` is set to an address determined by the system
-- `transactions` is an array of the derived deposits, encoded as per the two preceding sections.
+- `transactions` is an array of the derived transactions: deposited transactions and sequenced transactions.
+   All encoded with [EIP-2718]. Sequenced transactions must exclude any Deposit-type transactions.
 
 [expanded-payload]: exec-engine.md#extended-payloadattributesv1
 [`PayloadAttributesV1`]: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#payloadattributesv1

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -121,7 +121,7 @@ The rollup reads the following data from the [sequencing window][g-sequencing-wi
   - Sequencer batches, derived from the transactions:
     - The transaction receiver is the sequencer inbox address
     - The transaction must be signed by a recognized sequencer account
-    - The calldata may contain any number of batches. *(calldata will be substituted with blob data in the future.)*
+    - The calldata may contain a bundle of batches. *(calldata will be substituted with blob data in the future.)*
     - Batches not matching filter criteria are ignored:
       - `batch.epoch == sequencing_window.epoch`, i.e. for this sequencing window
       - `(batch.timestamp - genesis_l2_timestamp) % block_time == 0`, i.e. timestamp is aligned
@@ -131,9 +131,22 @@ The rollup reads the following data from the [sequencing window][g-sequencing-wi
 
 [random]: https://eips.ethereum.org/EIPS/eip-4399
 
-Batches are formatted as: `type ++ RLP([epoch, timestamp, transaction_list])`
+A bundle of batches is versioned by prefixing with a bundle version byte: `bundle = bundle_version ++ bundle_data`.
 
-- `type` is a single `byte` identifying the batch format
+Bundle versions:
+
+- `0`: `bundle_data = RLP([batch_0, batch_1, ..., batch_N])`
+- `1`: `bundle_data = compress(RLP([batch_0, batch_1, ..., batch_N]))` (compression algorithm TBD)
+
+A batch is also versioned by prefixing with a version byte: `batch = batch_version ++ batch_data`
+and encoded as a byte-string (including version prefix byte) in the bundle RLP list.
+
+Batch versions:
+
+- `0`: `batch_data = RLP([epoch, timestamp, transaction_list])`, where each
+
+Batch contents:
+
 - `epoch` is the sequencing window epoch, i.e. the first L1 block number
 - `timestamp` is the L2 timestamp of the block
 - `transaction_list` is an RLP encoded list of [EIP-2718] encoded transactions


### PR DESCRIPTION
This PR:
- Updates the rollup node doc:
  - define seq window (Fixes #183)
  - define seq batches
  - update sync (same, but need full seq window of blocks after finding common point)
  - misc updates, no more single block output, no deposit-blocks, etc.
- Updates the glossary with sequencing terms, and remove outdated "deposit block"

This PR does not spec the job of the sequencer to *produce* the data, this should probably go into a separate document, similar to how `proposing.md` is split out.


**Metadata**
- Fixes #183 
- Fixes ENG-1978