### PR TITLE
rollup node config

### DIFF
--- a/opnode/cmd/main.go
+++ b/opnode/cmd/main.go
@@ -2,16 +2,14 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"math/big"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/ethereum-optimism/optimistic-specs/opnode/node"
-	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/ethereum-optimism/optimistic-specs/opnode"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/flags"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/node"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli"
 )
@@ -43,7 +41,7 @@ func main() {
 	)
 
 	app := cli.NewApp()
-	app.Flags = Flags
+	app.Flags = flags.Flags
 	app.Version = VersionWithMeta
 	app.Name = "opnode"
 	app.Usage = "Optimism Rollup Node"
@@ -58,12 +56,12 @@ func main() {
 
 func RollupNodeMain(ctx *cli.Context) error {
 	log.Info("Initializing Rollup Node")
-	cfg, err := NewConfig(ctx)
+	cfg, err := opnode.NewConfig(ctx)
 	if err != nil {
 		log.Error("Unable to create the rollup node config", "error", err)
 		return err
 	}
-	logCfg, err := NewLogConfig(ctx)
+	logCfg, err := opnode.NewLogConfig(ctx)
 	if err != nil {
 		log.Error("Unable to create the log config", "error", err)
 		return err
@@ -96,127 +94,3 @@ func RollupNodeMain(ctx *cli.Context) error {
 	return nil
 
 }
-
-// HexToHash takes a `0x` prefixed hex hash string and turns it into a hash.
-// Errors are reported.
-func HexToHash(s string) (common.Hash, error) {
-	var x common.Hash
-	err := x.UnmarshalText([]byte(s))
-	return x, err
-}
-
-// NewConfig creates a Config from the provided flags or environment variables.
-func NewConfig(ctx *cli.Context) (*node.Config, error) {
-	L2Hash, err := HexToHash(ctx.GlobalString(GenesisL2Hash.Name))
-	if err != nil {
-		return nil, fmt.Errorf("Could not decode L2Hash: %w", err)
-	}
-	L1Hash, err := HexToHash(ctx.GlobalString(GenesisL1Hash.Name))
-	if err != nil {
-		return nil, fmt.Errorf("Could not decode L1Hash: %w", err)
-	}
-	cfg := &node.Config{
-		/* Required Flags */
-		L1NodeAddr:    ctx.GlobalString(L1NodeAddr.Name),
-		L2EngineAddrs: ctx.GlobalStringSlice(L2EngineAddrs.Name),
-		L2Hash:        L2Hash,
-		L1Hash:        L1Hash,
-		L1Num:         ctx.GlobalUint64(GenesisL2Hash.Name),
-		Rollup: rollup.Config{
-			BlockTime:            2,
-			MaxSequencerTimeDiff: 10,
-			SeqWindowSize:        64,
-			L1ChainID:            big.NewInt(901),
-			// TODO pick defaults
-			FeeRecipientAddress: common.Address{0xff, 0x01},
-			BatchInboxAddress:   common.Address{0xff, 0x02},
-			BatchSenderAddress:  common.Address{0xff, 0x03},
-		},
-	}
-	cfg.Rollup.Genesis = cfg.GetGenesis()
-	if err := cfg.Check(); err != nil {
-		return nil, err
-	}
-	return cfg, nil
-}
-
-// NewLogConfig creates a log config from the provided flags or environment variables.
-func NewLogConfig(ctx *cli.Context) (node.LogConfig, error) {
-	cfg := node.DefaultLogConfig() // Done to set color based on terminal type
-	cfg.Level = ctx.GlobalString(LogLevelFlag.Name)
-	cfg.Format = ctx.GlobalString(LogFormatFlag.Name)
-	if ctx.IsSet(LogColorFlag.Name) {
-		cfg.Color = ctx.GlobalBool(LogColorFlag.Name)
-	}
-
-	if err := cfg.Check(); err != nil {
-		return cfg, err
-	}
-	return cfg, nil
-}
-
-// Flags
-
-// Commented out for deadcode lint
-// const envVarPrefix = "ROLLUP_NODE_"
-// func prefixEnvVar(name string) string {
-// 	return envVarPrefix + name
-// }
-
-var Flags = []cli.Flag{
-	L1NodeAddr,
-	L2EngineAddrs,
-	GenesisL2Hash,
-	GenesisL1Hash,
-	GenesisL1Num,
-	LogLevelFlag,
-	LogFormatFlag,
-	LogColorFlag,
-}
-
-var (
-	/* Required Flags */
-	L1NodeAddr = cli.StringFlag{
-		Name:     "l1",
-		Usage:    "Address of L1 User JSON-RPC endpoint to use (eth namespace required)",
-		Required: true,
-		Value:    "http://127.0.0.1:8545",
-	}
-	L2EngineAddrs = cli.StringSliceFlag{
-		Name:     "l2",
-		Usage:    "Addresses of L2 Engine JSON-RPC endpoints to use (engine and eth namespace required)",
-		Required: true,
-	}
-	GenesisL2Hash = cli.StringFlag{
-		Name:     "genesis.l2-hash",
-		Usage:    "Genesis block hash of L2",
-		Required: true,
-	}
-	GenesisL1Hash = cli.StringFlag{
-		Name:     "genesis.l1-hash",
-		Usage:    "Block hash of L1 after (not incl.) which L1 starts deriving blocks",
-		Required: true,
-	}
-	GenesisL1Num = cli.Uint64Flag{
-		Name:     "genesis.l1-num",
-		Usage:    "Block number of L1 matching the l1-hash",
-		Required: true,
-	}
-
-	/* Optional Flags */
-
-	LogLevelFlag = cli.StringFlag{
-		Name:  "log.level",
-		Usage: "The lowest log level that will be output",
-		Value: "info",
-	}
-	LogFormatFlag = cli.StringFlag{
-		Name:  "log.format",
-		Usage: "Format the log output. Supported formats: 'text', 'json'",
-		Value: "text",
-	}
-	LogColorFlag = cli.BoolFlag{
-		Name:  "log.color",
-		Usage: "Color the log output",
-	}
-)

--- a/opnode/eth/id.go
+++ b/opnode/eth/id.go
@@ -7,8 +7,8 @@ import (
 )
 
 type BlockID struct {
-	Hash   common.Hash
-	Number uint64
+	Hash   common.Hash `json:"hash"`
+	Number uint64      `json:"number"`
 }
 
 func (id BlockID) String() string {
@@ -22,9 +22,9 @@ func (id BlockID) TerminalString() string {
 }
 
 type L2BlockRef struct {
-	Self     BlockID
-	Parent   BlockID
-	L1Origin BlockID
+	Self     BlockID `json:"self"`
+	Parent   BlockID `json:"parent"`
+	L1Origin BlockID `json:"l1_origin"`
 }
 
 func (id L2BlockRef) String() string {
@@ -38,8 +38,8 @@ func (id L2BlockRef) TerminalString() string {
 }
 
 type L1BlockRef struct {
-	Self   BlockID
-	Parent BlockID
+	Self   BlockID `json:"self"`
+	Parent BlockID `json:"parent"`
 }
 
 func (id L1BlockRef) String() string {

--- a/opnode/flags/flags.go
+++ b/opnode/flags/flags.go
@@ -1,0 +1,84 @@
+package flags
+
+import "github.com/urfave/cli"
+
+// Flags
+
+const envVarPrefix = "ROLLUP_NODE_"
+
+func prefixEnvVar(name string) string {
+	return envVarPrefix + name
+}
+
+var (
+	/* Required Flags */
+	L1NodeAddr = cli.StringFlag{
+		Name:     "l1",
+		Usage:    "Address of L1 User JSON-RPC endpoint to use (eth namespace required)",
+		Required: true,
+		Value:    "http://127.0.0.1:8545",
+		EnvVar:   prefixEnvVar("L1_ETH_RPC"),
+	}
+	L2EngineAddrs = cli.StringSliceFlag{
+		Name:     "l2",
+		Usage:    "Addresses of L2 Engine JSON-RPC endpoints to use (engine and eth namespace required)",
+		Required: true,
+		EnvVar:   prefixEnvVar("L2_ENGINE_RPC"),
+	}
+	RollupConfig = cli.StringFlag{
+		Name:     "rollup.config",
+		Usage:    "Rollup chain parameters",
+		Required: true,
+		EnvVar:   prefixEnvVar("ROLLUP_CONFIG"),
+	}
+
+	/* Optional Flags */
+
+	SequencingEnabledFlag = cli.BoolFlag{
+		Name:   "sequencing.enabled",
+		Usage:  "enable sequencing",
+		EnvVar: prefixEnvVar("SEQUENCING_ENABLED"),
+	}
+
+	// TODO: move batch submitter to stand-alone process
+	BatchSubmitterKeyFlag = cli.BoolFlag{
+		Name:   "batchsubmitter.key",
+		Usage:  "key for batch submitting",
+		EnvVar: prefixEnvVar("BATCHSUBMITTER_KEY"),
+	}
+
+	LogLevelFlag = cli.StringFlag{
+		Name:   "log.level",
+		Usage:  "The lowest log level that will be output",
+		Value:  "info",
+		EnvVar: prefixEnvVar("LOG_LEVEL"),
+	}
+	LogFormatFlag = cli.StringFlag{
+		Name:   "log.format",
+		Usage:  "Format the log output. Supported formats: 'text', 'json'",
+		Value:  "text",
+		EnvVar: prefixEnvVar("LOG_FORMAT"),
+	}
+	LogColorFlag = cli.BoolFlag{
+		Name:   "log.color",
+		Usage:  "Color the log output",
+		EnvVar: prefixEnvVar("LOG_COLOR"),
+	}
+)
+
+var requiredFlags = []cli.Flag{
+	L1NodeAddr,
+	L2EngineAddrs,
+	RollupConfig,
+}
+
+var optionalFlags = []cli.Flag{
+	SequencingEnabledFlag,
+	BatchSubmitterKeyFlag,
+	LogLevelFlag,
+	LogFormatFlag,
+	LogColorFlag,
+}
+
+// Flags contains the list of configuration options available to the binary.
+var Flags = append(requiredFlags, optionalFlags...)

--- a/opnode/flags/flags_test.go
+++ b/opnode/flags/flags_test.go
@@ -1,0 +1,28 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
+)
+
+// TestRequiredFlagsSetRequired asserts that all flags deemed required properly
+// have the Required field set to true.
+func TestRequiredFlagsSetRequired(t *testing.T) {
+	for _, flag := range requiredFlags {
+		reqFlag, ok := flag.(cli.RequiredFlag)
+		require.True(t, ok)
+		require.True(t, reqFlag.IsRequired())
+	}
+}
+
+// TestOptionalFlagsDontSetRequired asserts that all flags deemed optional set
+// the Required field to false.
+func TestOptionalFlagsDontSetRequired(t *testing.T) {
+	for _, flag := range optionalFlags {
+		reqFlag, ok := flag.(cli.RequiredFlag)
+		require.True(t, ok)
+		require.False(t, reqFlag.IsRequired())
+	}
+}

--- a/opnode/node/config.go
+++ b/opnode/node/config.go
@@ -1,0 +1,31 @@
+package node
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+)
+
+type Config struct {
+	// L1 and L2 nodes
+	L1NodeAddr    string   // Address of L1 User JSON-RPC endpoint to use (eth namespace required)
+	L2EngineAddrs []string // Addresses of L2 Engine JSON-RPC endpoints to use (engine and eth namespace required)
+
+	Rollup rollup.Config
+
+	// Sequencer flag, enables sequencing
+	Sequencer bool
+
+	// SubmitterPrivKey, temporary config var while the batch-submitter is part of the rollup node
+	SubmitterPrivKey *ecdsa.PrivateKey
+}
+
+// Check verifies that the given configuration makes sense
+func (cfg *Config) Check() error {
+	if err := cfg.Rollup.Check(); err != nil {
+		return fmt.Errorf("rollup config error: %v", err)
+	}
+
+	return nil
+}

--- a/opnode/node/log.go
+++ b/opnode/node/log.go
@@ -13,7 +13,6 @@ type LogConfig struct {
 	Level  string // Log level: trace, debug, info, warn, error, crit. Capitals are accepted too.
 	Color  bool   // Color the log output. Defaults to true if terminal is detected.
 	Format string // Format the log output. Supported formats: 'text', 'json'
-
 }
 
 func DefaultLogConfig() LogConfig {

--- a/opnode/node/node.go
+++ b/opnode/node/node.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"fmt"
 	"time"
 
@@ -10,50 +9,20 @@ import (
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/l1"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/l2"
-	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup/driver"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-type Config struct {
-	// L1 and L2 nodes
-	L1NodeAddr    string   // Address of L1 User JSON-RPC endpoint to use (eth namespace required)
-	L2EngineAddrs []string // Addresses of L2 Engine JSON-RPC endpoints to use (engine and eth namespace required)
-
-	// Genesis Information
-	L2Hash common.Hash // Genesis block hash of L2
-	L1Hash common.Hash // Block hash of L1 after (not incl.) which L1 starts deriving blocks
-	L1Num  uint64      // Block number of L1 matching the l1-hash
-
-	Rollup           rollup.Config
-	Sequencer        bool
-	SubmitterPrivKey *ecdsa.PrivateKey
-}
-
-// Check verifies that the given configuration makes sense
-func (cfg *Config) Check() error {
-	return nil
-}
-
 type OpNode struct {
 	log       log.Logger
 	l1Source  l1.Source        // Source to fetch data from (also implements the Downloader interface)
 	l2Engines []*driver.Driver // engines to keep synced
 	done      chan struct{}
-}
-
-func (conf *Config) GetGenesis() rollup.Genesis {
-	return rollup.Genesis{
-		L1: eth.BlockID{Hash: conf.L1Hash, Number: conf.L1Num},
-		// TODO: if we start from a squashed snapshot we might have a non-zero L2 genesis number
-		L2: eth.BlockID{Hash: conf.L2Hash, Number: 0},
-	}
 }
 
 func New(ctx context.Context, cfg *Config, log log.Logger) (*OpNode, error) {

--- a/opnode/rollup/types.go
+++ b/opnode/rollup/types.go
@@ -2,6 +2,7 @@ package rollup
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
@@ -48,10 +49,10 @@ type Config struct {
 // Check verifies that the given configuration makes sense
 func (cfg *Config) Check() error {
 	if cfg.BlockTime == 0 {
-		return errors.New("block time cannot be 0")
+		return fmt.Errorf("block time cannot be 0, got %d", cfg.BlockTime)
 	}
-	if cfg.SeqWindowSize == 0 {
-		return errors.New("sequencing window size cannot be 0")
+	if cfg.SeqWindowSize < 2 {
+		return fmt.Errorf("sequencing window size must at least be 2, got %d", cfg.SeqWindowSize)
 	}
 	if cfg.Genesis.L1.Hash == (common.Hash{}) {
 		return errors.New("genesis l1 hash cannot be empty")

--- a/opnode/rollup/types.go
+++ b/opnode/rollup/types.go
@@ -11,38 +11,38 @@ import (
 
 type Genesis struct {
 	// The L1 block that the rollup starts *after* (no derived transactions)
-	L1 eth.BlockID
+	L1 eth.BlockID `json:"l1"`
 	// The L2 block the rollup starts from (no transactions, pre-configured state)
-	L2 eth.BlockID
+	L2 eth.BlockID `json:"l2"`
 	// Timestamp of L2 block
-	L2Time uint64
+	L2Time uint64 `json:"l2_time"`
 }
 
 type Config struct {
 	// Genesis anchor point of the rollup
-	Genesis Genesis
+	Genesis Genesis `json:"genesis"`
 	// Seconds per L2 block
-	BlockTime uint64
+	BlockTime uint64 `json:"block_time"`
 	// Sequencer batches may not be more than MaxSequencerTimeDiff seconds after
 	// the L1 timestamp of the sequencing window end.
 	//
 	// Note: When L1 has many 1 second consecutive blocks, and L2 grows at fixed 2 seconds,
 	// the L2 time may still grow beyond this difference.
-	MaxSequencerTimeDiff uint64
+	MaxSequencerTimeDiff uint64 `json:"max_sequencer_time_diff"`
 	// Number of epochs (L1 blocks) per sequencing window
-	SeqWindowSize uint64
+	SeqWindowSize uint64 `json:"seq_window_size"`
 	// Required to verify L1 signatures
-	L1ChainID *big.Int
+	L1ChainID *big.Int `json:"l1_chain_id"`
 
 	// Note: below addresses are part of the block-derivation process,
 	// and required to be the same network-wide to stay in consensus.
 
 	// L2 address receiving all L2 transaction fees
-	FeeRecipientAddress common.Address
+	FeeRecipientAddress common.Address `json:"fee_recipient_address"`
 	// L1 address that batches are sent to
-	BatchInboxAddress common.Address
+	BatchInboxAddress common.Address `json:"batch_inbox_address"`
 	// Acceptable batch-sender address
-	BatchSenderAddress common.Address
+	BatchSenderAddress common.Address `json:"batch_sender_address"`
 }
 
 // Check verifies that the given configuration makes sense

--- a/opnode/rollup/types.go
+++ b/opnode/rollup/types.go
@@ -1,6 +1,7 @@
 package rollup
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
@@ -33,12 +34,35 @@ type Config struct {
 	// Required to verify L1 signatures
 	L1ChainID *big.Int
 
+	// Note: below addresses are part of the block-derivation process,
+	// and required to be the same network-wide to stay in consensus.
+
 	// L2 address receiving all L2 transaction fees
 	FeeRecipientAddress common.Address
 	// L1 address that batches are sent to
 	BatchInboxAddress common.Address
 	// Acceptable batch-sender address
 	BatchSenderAddress common.Address
+}
+
+// Check verifies that the given configuration makes sense
+func (cfg *Config) Check() error {
+	if cfg.BlockTime == 0 {
+		return errors.New("block time cannot be 0")
+	}
+	if cfg.SeqWindowSize == 0 {
+		return errors.New("sequencing window size cannot be 0")
+	}
+	if cfg.Genesis.L1.Hash == (common.Hash{}) {
+		return errors.New("genesis l1 hash cannot be empty")
+	}
+	if cfg.Genesis.L2.Hash == (common.Hash{}) {
+		return errors.New("genesis l2 hash cannot be empty")
+	}
+	if cfg.Genesis.L2.Hash == cfg.Genesis.L1.Hash {
+		return errors.New("achievement get! rollup inception: L1 and L2 genesis cannot be the same")
+	}
+	return nil
 }
 
 func (c *Config) L1Signer() types.Signer {

--- a/opnode/rollup/types_test.go
+++ b/opnode/rollup/types_test.go
@@ -1,0 +1,47 @@
+package rollup
+
+import (
+	"encoding/json"
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func randConfig() *Config {
+	randHash := func() (out common.Hash) {
+		rand.Read(out[:])
+		return
+	}
+	randAddr := func() (out common.Address) { // we need generics...
+		rand.Read(out[:])
+		return
+	}
+	return &Config{
+		Genesis: Genesis{
+			L1:     eth.BlockID{Hash: randHash(), Number: 424242},
+			L2:     eth.BlockID{Hash: randHash(), Number: 1337},
+			L2Time: uint64(time.Now().Unix()),
+		},
+		BlockTime:            2,
+		MaxSequencerTimeDiff: 100,
+		SeqWindowSize:        2,
+		L1ChainID:            big.NewInt(900),
+		FeeRecipientAddress:  randAddr(),
+		BatchInboxAddress:    randAddr(),
+		BatchSenderAddress:   randAddr(),
+	}
+}
+
+func TestConfigJSON(t *testing.T) {
+	config := randConfig()
+	data, err := json.Marshal(config)
+	assert.NoError(t, err)
+	var roundTripped Config
+	assert.NoError(t, json.Unmarshal(data, &roundTripped))
+	assert.Equal(t, &roundTripped, config)
+}

--- a/opnode/service.go
+++ b/opnode/service.go
@@ -1,0 +1,82 @@
+package opnode
+
+import (
+	"crypto/ecdsa"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/flags"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/node"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/urfave/cli"
+)
+
+// NewConfig creates a Config from the provided flags or environment variables.
+func NewConfig(ctx *cli.Context) (*node.Config, error) {
+	rollupConfig, err := NewRollupConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	enableSequencing := ctx.GlobalBool(flags.SequencingEnabledFlag.Name)
+
+	var batchSubmitterKey *ecdsa.PrivateKey
+	if enableSequencing {
+		keyFile := ctx.GlobalString(flags.BatchSubmitterKeyFlag.Name)
+		if keyFile == "" {
+			return nil, errors.New("sequencer mode needs batch-submitter key")
+		}
+		// TODO we should be using encrypted keystores.
+		// Mnemonics are bad because they leak *all* keys when they leak
+		// Unencrypted keys from file are bad because they are easy to leak (and we are not checking file permissions)
+		batchSubmitterKey, err = crypto.LoadECDSA(keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read batch submitter key: %v", err)
+		}
+	}
+
+	cfg := &node.Config{
+		L1NodeAddr:       ctx.GlobalString(flags.L1NodeAddr.Name),
+		L2EngineAddrs:    ctx.GlobalStringSlice(flags.L2EngineAddrs.Name),
+		Rollup:           *rollupConfig,
+		Sequencer:        enableSequencing,
+		SubmitterPrivKey: batchSubmitterKey,
+	}
+	if err := cfg.Check(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func NewRollupConfig(ctx *cli.Context) (*rollup.Config, error) {
+	rollupConfigPath := ctx.GlobalString(flags.RollupConfig.Name)
+	file, err := os.Open(rollupConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read rollup config: %v", err)
+	}
+	defer file.Close()
+
+	var rollupConfig rollup.Config
+	if err := json.NewDecoder(file).Decode(&rollupConfig); err != nil {
+		return nil, fmt.Errorf("failed to decode rollup config: %v", err)
+	}
+	return &rollupConfig, nil
+}
+
+// NewLogConfig creates a log config from the provided flags or environment variables.
+func NewLogConfig(ctx *cli.Context) (node.LogConfig, error) {
+	cfg := node.DefaultLogConfig() // Done to set color based on terminal type
+	cfg.Level = ctx.GlobalString(flags.LogLevelFlag.Name)
+	cfg.Format = ctx.GlobalString(flags.LogFormatFlag.Name)
+	if ctx.IsSet(flags.LogColorFlag.Name) {
+		cfg.Color = ctx.GlobalBool(flags.LogColorFlag.Name)
+	}
+
+	if err := cfg.Check(); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}


### PR DESCRIPTION
- Split config flags into flags package, like the output submitter does
- Define `--sequencing.enabled` flag to enable sequencer
- Define `--batchsubmitter.key` key flag to load key for batch submitter, from a file with hex-encoded priv key.
- De-duplicate genesis config values
- Properly set L2 genesis time in e2e test
- Load rollup-config (chain params) from json file, a required flag `rollup.config`
- Implement `Check()` for rollup-config, prevent common configuration errors
- Update config / block id / block reference types for JSON encoding
- Move flag parsing and config creation to `opnode` package root (mirrors how output submitter does it), to make it reusable
- Define environment vars for rollup node flags

No rollup-config defaults yet, there's no public testnet to point it to.

Fix #222 
