### PR TITLE
opnode,specs: define max_l2_seq_time_diff, default to l2 block time

### DIFF
--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
@@ -152,6 +153,10 @@ func (s *state) loop() {
 			// 2. Ask output to create new block
 			newUnsafeL2Head, batch, err := s.output.newBlock(context.Background(), s.l2Finalized, s.l2Head, s.l2SafeHead, s.l1Origin, firstOfEpoch)
 			if err != nil {
+				if errors.Is(err, newBlockTooNew) {
+					s.log.Trace("Tried to build L2 block, but latest L1 time is already reached by L2")
+					continue
+				}
 				s.log.Error("Could not extend chain as sequencer", "err", err, "l2UnsafeHead", s.l2Head, "l1Origin", s.l1Origin)
 				continue
 			}

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -167,7 +167,7 @@ func TestSystemE2E(t *testing.T) {
 				L2Time: l2GenesisTime,
 			},
 			BlockTime:            1,
-			MaxSequencerTimeDiff: 10,
+			MaxSequencerTimeDiff: 1,
 			SeqWindowSize:        2,
 			L1ChainID:            big.NewInt(900),
 			// TODO pick defaults
@@ -194,7 +194,7 @@ func TestSystemE2E(t *testing.T) {
 				L2Time: l2GenesisTime,
 			},
 			BlockTime:            1,
-			MaxSequencerTimeDiff: 10,
+			MaxSequencerTimeDiff: 1,
 			SeqWindowSize:        2,
 			L1ChainID:            big.NewInt(900),
 			// TODO pick defaults

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -91,10 +91,12 @@ meaning that gaps between the batches (ordered by timestamp) are interpreted as 
 thus construing L2 blocks that only contain deposit transaction(s).
 
 The L2 blocks produced by a sequencing window are bounded by timestamp:
+`min_l2_timestamp <= block.timestamp < max_l2_timestamp`
 
 - `min_l2_timestamp = prev_l2_timestamp + l2_block_time`
-- `max_l2_timestamp = l1_timestamp + l2_block_time`, where `l1_timestamp` is the timestamp of the
-  first L1 block of the sequencing window. (maximum bound, may not be aligned with block time)
+- `max_l2_timestamp = l1_timestamp + max_l2_seq_time_diff` is the maximum bound, and may not be aligned with block time.
+  - `l1_timestamp` is the timestamp of the first L1 block of the sequencing window,
+  - `max_l2_seq_time_diff` is the time a L2 sequencer can be ahead of L1, which defaults to `l2_block_time`.
 
 If there are no batches present in the sequencing window then the L2 chain is extended up to `max_l2_timestamp` (incl.)
 with empty batches, but otherwise regular block derivation.


### PR DESCRIPTION
- Define the time a sequencer can get ahead of the last L1 block time as a rollup config param
- Default to block time
- Update specs
- Catch error when producing block that's too far ahead. Simply retry the next L2 block time interval to produce a block that's not too far ahead. This error was previously making noise in e2e.

I think we should consider experimenting with increasing the `max_l2_seq_time_diff`, since I expect the L2 blocks to be build at their timestamp. If we wait for the next L1 block, the L2 blocks we are building between the previous L1 head and the new L1 head are already old. I would expect this to be set to the *expected* L1 block time.

Also, when the L1 is not producing blocks for whatever reason, then this is the only parameter we have to keep the L2 going without making code changes, a good thing to have.

