### PR TITLE
fix: test_basefee now tests basefee

### DIFF
--- a/packages/contracts/contracts/test/L1Block.t.sol
+++ b/packages/contracts/contracts/test/L1Block.t.sol
@@ -29,7 +29,7 @@ contract L1BLockTest is DSTest {
     }
 
     function test_basefee() external {
-        assertEq(lb.timestamp(), 2);
+        assertEq(lb.basefee(), 3);
     }
 
     function test_hash() external {


### PR DESCRIPTION
**Description**

Fixes basefee test, which previously tested the timestamp field

**Metadata**

Introduced in https://github.com/ethereum-optimism/optimistic-specs/pull/265
