### PR TITLE
opnode/rollup/derive,specs: fix / harden deposit processing

### DIFF
--- a/opnode/l1/source.go
+++ b/opnode/l1/source.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/trie"
+
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup/derive"
 	"github.com/ethereum/go-ethereum"
@@ -64,9 +66,19 @@ func (s Source) FetchL1Info(ctx context.Context, id eth.BlockID) (derive.L1Info,
 	return s.client.BlockByHash(ctx, id.Hash)
 }
 
-func (s Source) FetchReceipts(ctx context.Context, id eth.BlockID) ([]*types.Receipt, error) {
+func (s Source) FetchReceipts(ctx context.Context, id eth.BlockID, receiptHash common.Hash) ([]*types.Receipt, error) {
 	_, receipts, err := s.Fetch(ctx, id)
-	return receipts, err
+	if err != nil {
+		return nil, err
+	}
+	// Sanity-check: external L1-RPC sources are notorious for not returning all receipts,
+	// or returning them out-of-order. Verify the receipts against the expected receipt-hash.
+	hasher := trie.NewStackTrie(nil)
+	computed := types.DeriveSha(types.Receipts(receipts), hasher)
+	if receiptHash != computed {
+		return nil, fmt.Errorf("failed to validate receipts of %s, computed receipt-hash %s does not match expected hash %d", id, computed, receiptHash)
+	}
+	return receipts, nil
 }
 
 func (s Source) FetchTransactions(ctx context.Context, window []eth.BlockID) ([]*types.Transaction, error) {
@@ -79,7 +91,6 @@ func (s Source) FetchTransactions(ctx context.Context, window []eth.BlockID) ([]
 		txns = append(txns, block.Transactions()...)
 	}
 	return txns, nil
-
 }
 func (s Source) L1HeadBlockRef(ctx context.Context) (eth.L1BlockRef, error) {
 	return s.l1BlockRefByNumber(ctx, nil)

--- a/opnode/rollup/derive/invert_test.go
+++ b/opnode/rollup/derive/invert_test.go
@@ -5,16 +5,21 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 )
 
 type l1MockInfo struct {
-	num       uint64
-	time      uint64
-	hash      common.Hash
-	baseFee   *big.Int
-	mixDigest [32]byte
+	num         uint64
+	time        uint64
+	hash        common.Hash
+	baseFee     *big.Int
+	mixDigest   [32]byte
+	receiptRoot common.Hash
 }
 
 func (l *l1MockInfo) NumberU64() uint64 {
@@ -37,6 +42,10 @@ func (l *l1MockInfo) MixDigest() common.Hash {
 	return l.mixDigest
 }
 
+func (l *l1MockInfo) ReceiptHash() common.Hash {
+	return l.receiptRoot
+}
+
 func randomHash(rng *rand.Rand) (out common.Hash) {
 	rng.Read(out[:])
 	return
@@ -44,10 +53,11 @@ func randomHash(rng *rand.Rand) (out common.Hash) {
 
 func randomL1Info(rng *rand.Rand) *l1MockInfo {
 	return &l1MockInfo{
-		num:     rng.Uint64(),
-		time:    rng.Uint64(),
-		hash:    randomHash(rng),
-		baseFee: big.NewInt(rng.Int63n(1000_0000 * 1e9)), // a million GWEI
+		num:         rng.Uint64(),
+		time:        rng.Uint64(),
+		hash:        randomHash(rng),
+		baseFee:     big.NewInt(rng.Int63n(1000_000 * params.GWei)), // a million GWEI
+		receiptRoot: types.EmptyRootHash,
 	}
 }
 

--- a/opnode/rollup/derive/payload_attributes_test.go
+++ b/opnode/rollup/derive/payload_attributes_test.go
@@ -7,6 +7,9 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -192,6 +195,131 @@ func TestDeriveUserDeposits(t *testing.T) {
 			for d, depTx := range got {
 				expected := expectedDeposits[d]
 				assert.Equal(t, expected, depTx)
+			}
+		})
+	}
+}
+
+type ValidBatchTestCase struct {
+	Name      string
+	Epoch     rollup.Epoch
+	MinL2Time uint64
+	MaxL2Time uint64
+	Batch     BatchData
+	Valid     bool
+}
+
+func TestValidBatch(t *testing.T) {
+	testCases := []ValidBatchTestCase{
+		{
+			Name:      "valid epoch",
+			Epoch:     123,
+			MinL2Time: 43,
+			MaxL2Time: 52,
+			Batch: BatchData{BatchV1: BatchV1{
+				Epoch:        123,
+				Timestamp:    43,
+				Transactions: []hexutil.Bytes{{0x01, 0x13, 0x37}, {0x02, 0x13, 0x37}},
+			}},
+			Valid: true,
+		},
+		{
+			Name:      "ignored epoch",
+			Epoch:     123,
+			MinL2Time: 43,
+			MaxL2Time: 52,
+			Batch: BatchData{BatchV1: BatchV1{
+				Epoch:        122,
+				Timestamp:    43,
+				Transactions: nil,
+			}},
+			Valid: false,
+		},
+		{
+			Name:      "too old",
+			Epoch:     123,
+			MinL2Time: 43,
+			MaxL2Time: 52,
+			Batch: BatchData{BatchV1: BatchV1{
+				Epoch:        123,
+				Timestamp:    42,
+				Transactions: nil,
+			}},
+			Valid: false,
+		},
+		{
+			Name:      "too new",
+			Epoch:     123,
+			MinL2Time: 43,
+			MaxL2Time: 52,
+			Batch: BatchData{BatchV1: BatchV1{
+				Epoch:        123,
+				Timestamp:    52,
+				Transactions: nil,
+			}},
+			Valid: false,
+		},
+		{
+			Name:      "wrong time alignment",
+			Epoch:     123,
+			MinL2Time: 43,
+			MaxL2Time: 52,
+			Batch: BatchData{BatchV1: BatchV1{
+				Epoch:        123,
+				Timestamp:    46,
+				Transactions: nil,
+			}},
+			Valid: false,
+		},
+		{
+			Name:      "good time alignment",
+			Epoch:     123,
+			MinL2Time: 43,
+			MaxL2Time: 52,
+			Batch: BatchData{BatchV1: BatchV1{
+				Epoch:        123,
+				Timestamp:    51, // 31 + 2*10
+				Transactions: nil,
+			}},
+			Valid: true,
+		},
+		{
+			Name:      "empty tx",
+			Epoch:     123,
+			MinL2Time: 43,
+			MaxL2Time: 52,
+			Batch: BatchData{BatchV1: BatchV1{
+				Epoch:        123,
+				Timestamp:    43,
+				Transactions: []hexutil.Bytes{{}},
+			}},
+			Valid: false,
+		},
+		{
+			Name:      "sneaky deposit",
+			Epoch:     123,
+			MinL2Time: 43,
+			MaxL2Time: 52,
+			Batch: BatchData{BatchV1: BatchV1{
+				Epoch:        123,
+				Timestamp:    43,
+				Transactions: []hexutil.Bytes{{0x01}, {types.DepositTxType, 0x13, 0x37}, {0xc0, 0x13, 0x37}},
+			}},
+			Valid: false,
+		},
+	}
+	conf := rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 31, // a genesis time that itself does not align to make it more interesting
+		},
+		BlockTime: 2,
+		// other config fields are ignored and can be left empty.
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := ValidBatch(&testCase.Batch, &conf, testCase.Epoch, testCase.MinL2Time, testCase.MaxL2Time)
+			if got != testCase.Valid {
+				t.Fatalf("case %v was expected to return %v, but got %v", testCase, testCase.Valid, got)
 			}
 		})
 	}

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -25,8 +25,8 @@ type BatchSubmitter interface {
 type Downloader interface {
 	// FetchL1Info fetches the L1 header information corresponding to a L1 block ID
 	FetchL1Info(ctx context.Context, id eth.BlockID) (derive.L1Info, error)
-	// FetchReceipts of a L1 block
-	FetchReceipts(ctx context.Context, id eth.BlockID) ([]*types.Receipt, error)
+	// FetchReceipts of a L1 block. The receipt-hash must be provided to sanity-check the retrieved receipts.
+	FetchReceipts(ctx context.Context, id eth.BlockID, receiptHash common.Hash) ([]*types.Receipt, error)
 	// FetchTransactions from the given window of L1 blocks
 	FetchTransactions(ctx context.Context, window []eth.BlockID) ([]*types.Transaction, error)
 }

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -8,6 +8,7 @@
 [g-l1-attr-deposit]: glossary.md#l1-attributes-deposited-transaction
 [g-user-deposited]: glossary.md#user-deposited-transaction
 [g-eoa]: glossary.md#eoa
+[g-exec-engine]: glossary.md#execution-engine
 
 [Deposited transactions][g-deposited], also known as [deposits][g-deposits] are transactions which
 are initiated on L1, and executed on L2. This document outlines a new [transaction
@@ -54,6 +55,8 @@ fields (rlp encoded in the order they appear here):
 
 [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 
+- `uint64 blockHeight`: the block-height of the L2 block
+- `uint64 transactionIndex`: the transaction-index within the L2 transactions list
 - `address from`: The address of the sender account.
 - `address to`: The address of the recipient account, or the null (zero-length) address if the
   deposited transaction is a contract creation.
@@ -71,6 +74,12 @@ We select `0x7E` because transaction type identifiers are currently allowed to g
 Picking a high identifier minimizes the risk that the identifier will be used be claimed by another
 transaction type on the L1 chain in the future. We don't pick `0x7F` itself in case it becomes used
 for a variable-length encoding scheme.
+
+The extra blockHeight and transactionIndex in deposits will be used to ensure that deposited transactions
+will be unique. Without them, two different deposited transaction could have the same exact hash.
+
+We do not use the sender's nonce to ensure uniqueness because this would require an extra L2 EVM state read from the
+[execution engine][g-exec-engine] during block-derivation.
 
 ### Kinds of Deposited Transactions
 

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -114,9 +114,8 @@ The rollup reads the following data from the [sequencing window][g-sequencing-wi
     - timestamp
     - basefee
     - *random* (the output of the [`RANDOM` opcode][random])
-  - L1 log entries emitted for [user deposits][g-deposits], augmented with
-    - `blockHeight`: the block-height of the L1 block
-    - `transactionIndex`: the transaction-index within the L2 transactions list
+  - L1 log entries emitted for [user deposits][g-deposits], derived transactions are augmented with
+    `blockHeight` and `transactionIndex` of the transaction in L2.
 - Of each block in the window:
   - Sequencer batches, derived from the transactions:
     - The transaction receiver is the sequencer inbox address
@@ -153,12 +152,6 @@ Batch contents:
 - `transaction_list` is an RLP encoded list of [EIP-2718] encoded transactions.
 
 [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
-
-> Design note: The extra log entry metadata will be used to ensure that deposited transactions will be unique. Without
-> them, two different deposited transaction could have the same exact hash.
->
-> We do not use the sender's nonce to ensure uniqueness because this would require an extra L2 EVM state read from the
-> [execution engine][g-exec-engine].
 
 The L1 attributes are read from the L1 block header, while deposits are read from the block's [receipts][g-receipts].
 Refer to the [**deposit contract specification**][deposit-contract-spec] for details on how deposits are encoded as log


### PR DESCRIPTION
- bugfix: verify batch does not contain deposit tx type (otherwise sequencers can insert fake deposits into batches)
- sanity-check receipts (most common deposit processing problem in eth2)
- use L2 block-height to ensure uniqueness of deposits when there are multiple L2 blocks with L1 info deposits per L1 block
- update specs (clarify deposit contents, move design text about uniqueness)
- update mock type in tests (l1 info interface has receipt hash now)
- test `ValidBatch` function

