### PR TITLE
feat: DepositFeed receive function

### DIFF
--- a/packages/contracts/contracts/L1/DepositFeed.sol
+++ b/packages/contracts/contracts/L1/DepositFeed.sol
@@ -27,6 +27,14 @@ contract DepositFeed {
     );
 
     /**
+     * Accepts value deposits where users can send ETH directly to
+     * the smart contract address and have the funds be deposited
+     */
+    receive() external payable {
+        depositTransaction(msg.sender, msg.value, 30000, false, bytes(""));
+    }
+
+    /**
      * Accepts deposits of ETH and data, and emits a TransactionDeposited event for use in deriving
      * deposit transactions.
      * @param _to The L2 destination address.
@@ -41,7 +49,7 @@ contract DepositFeed {
         uint256 _gasLimit,
         bool _isCreation,
         bytes memory _data
-    ) external payable {
+    ) public payable {
         if (_isCreation && _to != address(0)) {
             revert NonZeroCreationTarget();
         }

--- a/packages/contracts/test/L1/DepositFeed.spec.ts
+++ b/packages/contracts/test/L1/DepositFeed.spec.ts
@@ -310,6 +310,32 @@ describe('DepositFeed', () => {
           data: NON_ZERO_DATA,
         })
       })
+
+      it('when doing a simple send', async () => {
+        const balBefore = await ethers.provider.getBalance(depositFeed.address)
+
+        const tx = await signer.sendTransaction({
+          to: depositFeed.address,
+          value: NON_ZERO_VALUE,
+        })
+
+        const receipt = await tx.wait()
+        expect(receipt.status).to.equal(1)
+
+        const balAfter = await ethers.provider.getBalance(depositFeed.address)
+        const eventArgs = await decodeDepositEvent(depositFeed)
+
+        expect(balAfter.sub(balBefore)).to.equal(NON_ZERO_VALUE)
+        expect(eventArgs).to.deep.equal({
+          from: signerAddress,
+          to: await signer.getAddress(),
+          value: NON_ZERO_VALUE,
+          mint: NON_ZERO_VALUE,
+          gasLimit: BigNumber.from(30000),
+          isCreation: false,
+          data: '0x',
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
**Description**

It is convenient for users to be able to deposit funds
directly to L2 by simply doing an ETH send to an address.
The prevents needing an ABI.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

