### PR TITLE
opnode: Switch to BlockRefs in state loop

### DIFF
--- a/opnode/l1/source.go
+++ b/opnode/l1/source.go
@@ -125,7 +125,7 @@ func (s Source) L1Range(ctx context.Context, begin eth.BlockID) ([]eth.BlockID, 
 	if canonicalBegin, err := s.L1BlockRefByNumber(ctx, begin.Number); err != nil {
 		return nil, fmt.Errorf("failed to fetch L1 block %v %v: %w", begin.Number, begin.Hash, err)
 	} else {
-		if canonicalBegin.Self != begin {
+		if canonicalBegin.Self.Hash != begin.Hash {
 			return nil, fmt.Errorf("Re-org at begin block. Expected: %v. Actual: %v", begin, canonicalBegin.Self)
 		}
 	}

--- a/opnode/l2/api.go
+++ b/opnode/l2/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 )
 
@@ -88,26 +89,58 @@ type Data = hexutil.Bytes
 type PayloadID = hexutil.Bytes
 
 type ExecutionPayload struct {
-	ParentHash    common.Hash     `json:"parentHash"`
-	FeeRecipient  common.Address  `json:"feeRecipient"`
-	StateRoot     Bytes32         `json:"stateRoot"`
-	ReceiptsRoot  Bytes32         `json:"receiptsRoot"`
-	LogsBloom     Bytes256        `json:"logsBloom"`
-	Random        Bytes32         `json:"random"`
-	BlockNumber   Uint64Quantity  `json:"blockNumber"`
-	GasLimit      Uint64Quantity  `json:"gasLimit"`
-	GasUsed       Uint64Quantity  `json:"gasUsed"`
-	Timestamp     Uint64Quantity  `json:"timestamp"`
-	ExtraData     BytesMax32      `json:"extraData"`
-	BaseFeePerGas Uint256Quantity `json:"baseFeePerGas"`
-	BlockHash     common.Hash     `json:"blockHash"`
+	ParentHashField common.Hash     `json:"parentHash"`
+	FeeRecipient    common.Address  `json:"feeRecipient"`
+	StateRoot       Bytes32         `json:"stateRoot"`
+	ReceiptsRoot    Bytes32         `json:"receiptsRoot"`
+	LogsBloom       Bytes256        `json:"logsBloom"`
+	Random          Bytes32         `json:"random"`
+	BlockNumber     Uint64Quantity  `json:"blockNumber"`
+	GasLimit        Uint64Quantity  `json:"gasLimit"`
+	GasUsed         Uint64Quantity  `json:"gasUsed"`
+	Timestamp       Uint64Quantity  `json:"timestamp"`
+	ExtraData       BytesMax32      `json:"extraData"`
+	BaseFeePerGas   Uint256Quantity `json:"baseFeePerGas"`
+	BlockHash       common.Hash     `json:"blockHash"`
 	// Array of transaction objects, each object is a byte list (DATA) representing
 	// TransactionType || TransactionPayload or LegacyTransaction as defined in EIP-2718
-	Transactions []Data `json:"transactions"`
+	TransactionsField []Data `json:"transactions"`
 }
 
 func (payload *ExecutionPayload) ID() eth.BlockID {
 	return eth.BlockID{Hash: payload.BlockHash, Number: uint64(payload.BlockNumber)}
+}
+
+// Implement block interface to enable derive.BlockReferences over a payload
+// type Block interface {
+// 	Hash() common.Hash
+// 	NumberU64() uint64
+// 	ParentHash() common.Hash
+// 	Transactions() types.Transactions
+// }
+
+func (payload *ExecutionPayload) Hash() common.Hash {
+	return payload.BlockHash
+}
+
+func (payload *ExecutionPayload) NumberU64() uint64 {
+	return uint64(payload.BlockNumber)
+}
+
+func (payload *ExecutionPayload) ParentHash() common.Hash {
+	return payload.ParentHashField
+}
+
+func (payload *ExecutionPayload) Transactions() types.Transactions {
+	res := make([]*types.Transaction, len(payload.TransactionsField))
+	for i, t := range payload.TransactionsField {
+		res[i] = new(types.Transaction)
+		err := res[i].UnmarshalBinary(t)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return res
 }
 
 type PayloadAttributes struct {

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -51,8 +51,8 @@ type L2Chain interface {
 }
 
 type outputInterface interface {
-	step(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.BlockID, error)
-	newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.BlockID, l2Safe eth.BlockID, l1Origin eth.BlockID, includeDeposits bool) (eth.BlockID, *derive.BatchData, error)
+	step(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.L2BlockRef, error)
+	newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.L2BlockRef, l2Safe eth.BlockID, l1Origin eth.BlockID) (eth.L2BlockRef, *derive.BatchData, error)
 }
 
 func NewDriver(cfg rollup.Config, l2 *l2.Source, l1 *l1.Source, log log.Logger, submitter BatchSubmitter, sequencer bool) *Driver {

--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -13,13 +13,11 @@ import (
 
 type state struct {
 	// Chain State
-	l1Head      eth.BlockID   // Latest recorded head of the L1 Chain
-	l2Head      eth.BlockID   // L2 Unsafe Head
-	l1Origin    eth.BlockID   // L1 Origin of the L2 Unsafe head. For sequencing only.
-	l2SafeHead  eth.BlockID   // L2 Safe Head - this is the head of the L2 chain as derived from L1 (thus it is Sequencer window blocks behind)
-	l1Base      eth.BlockID   // L1 Parent of L2 Safe Head block
-	l2Finalized eth.BlockID   // L2 Block that will never be reversed
-	l1Window    []eth.BlockID // l1Window buffers the next L1 block IDs to derive new L2 blocks from, with increasing block height.
+	l1Head      eth.L1BlockRef // Latest recorded head of the L1 Chain
+	l2Head      eth.L2BlockRef // L2 Unsafe Head
+	l2SafeHead  eth.L2BlockRef // L2 Safe Head - this is the head of the L2 chain as derived from L1 (thus it is Sequencer window blocks behind)
+	l2Finalized eth.BlockID    // L2 Block that will never be reversed
+	l1Window    []eth.BlockID  // l1Window buffers the next L1 block IDs to derive new L2 blocks from, with increasing block height.
 
 	// Rollup config
 	Config    rollup.Config
@@ -35,6 +33,11 @@ type state struct {
 	log  log.Logger
 	done chan struct{}
 }
+
+// // shouldRunEpoch returns true if there is a full sequencing window between the L2 Safe Head's L1 Origin and the L1 Head.
+// func (s *state) shouldRunEpoch() bool {
+// 	return s.l1Head.Self.Number-s.l2SafeHead.L1Origin.Number >= s.Config.SeqWindowSize
+// }
 
 func NewState(log log.Logger, config rollup.Config, l1 L1Chain, l2 L2Chain, output outputInterface, submitter BatchSubmitter, sequencer bool) *state {
 	return &state{
@@ -59,12 +62,12 @@ func (s *state) Start(ctx context.Context, l1Heads <-chan eth.L1BlockRef) error 
 		return err
 	}
 
-	//  TODO: Don't start everything from L2 heads
-	s.l1Head = l1Head.Self
-	s.l1Origin = s.l1Head
-	s.l2Head = l2Head.Self // TODO: Makes sense?
-	s.l2SafeHead = l2Head.Self
-	s.l1Base = l2Head.L1Origin
+	// TODO:
+	// 1. Pull safehead from sync-start algorithm
+	// 2. Check if heads are below genesis & if so, bump to genesis.
+	s.l1Head = l1Head
+	s.l2Head = l2Head
+	s.l2SafeHead = l2Head
 	s.l1Heads = l1Heads
 
 	go s.loop()
@@ -80,7 +83,7 @@ func (s *state) Close() error {
 // This is either the last block of the window, or the L1 base block if the window is not populated.
 func (s *state) l1WindowEnd() eth.BlockID {
 	if len(s.l1Window) == 0 {
-		return s.l1Base
+		return s.l2Head.L1Origin
 	}
 	return s.l1Window[len(s.l1Window)-1]
 }
@@ -104,6 +107,19 @@ func (s *state) sequencingWindow() ([]eth.BlockID, bool) {
 		return nil, false
 	}
 	return s.l1Window[:int(s.Config.SeqWindowSize)], true
+}
+
+func (s *state) findNextL1Origin(ctx context.Context) (eth.BlockID, error) {
+	return s.l1Head.Self, nil // Temporary until timestamps are working correctly
+	// [prev L2 + blocktime, L1 Bock)
+	// currentL1Origin := s.l2Head.L1Origin
+	// s.log.Info("Find next l1Origin", "l2Head", s.l2Head, "l1Origin", currentL1Origin)
+	// if s.l2Head.Time+int64(s.Config.BlockTime) >= currentL1Origin.Time {
+	// 	ref, err := s.l1.L1BlockRefByNumber(ctx, currentL1Origin.Number+1)
+	// 	s.log.Info("Lookuing up new L1 Origin", "nextL1Origin", ref)
+	// 	return ref.Self, err
+	// }
+	// return currentL1Origin, nil
 }
 
 func (s *state) loop() {
@@ -139,20 +155,18 @@ func (s *state) loop() {
 		case <-s.done:
 			return
 		case <-l2BlockCreation:
-			// 1. Check if new epoch (new L1 head)
-			firstOfEpoch := false
-			if s.l1Head != s.l1Origin {
-				firstOfEpoch = true
-				s.l1Origin = s.l1Head
+			nextOrigin, err := s.findNextL1Origin(context.Background())
+			if err != nil {
+				continue
 			}
 			// Don't produce blocks until past the L1 genesis
-			if s.l1Origin.Number <= s.Config.Genesis.L1.Number {
+			if nextOrigin.Number <= s.Config.Genesis.L1.Number {
 				continue
 			}
 			// 2. Ask output to create new block
-			newUnsafeL2Head, batch, err := s.output.newBlock(context.Background(), s.l2Finalized, s.l2Head, s.l2SafeHead, s.l1Origin, firstOfEpoch)
+			newUnsafeL2Head, batch, err := s.output.newBlock(context.Background(), s.l2Finalized, s.l2Head, s.l2SafeHead.Self, nextOrigin)
 			if err != nil {
-				s.log.Error("Could not extend chain as sequencer", "err", err, "l2UnsafeHead", s.l2Head, "l1Origin", s.l1Origin)
+				s.log.Error("Could not extend chain as sequencer", "err", err, "l2UnsafeHead", s.l2Head, "l1Origin", nextOrigin)
 				continue
 			}
 			// 3. Update unsafe l2 head + epoch
@@ -169,15 +183,15 @@ func (s *state) loop() {
 		case newL1Head := <-s.l1Heads:
 			s.log.Trace("Received new L1 Head", "new_head", newL1Head.Self, "old_head", s.l1Head)
 			// Check if we have a stutter step. May be due to a L1 Poll operation.
-			if s.l1Head == newL1Head.Self {
+			if s.l1Head.Self.Hash == newL1Head.Self.Hash {
 				log.Trace("Received L1 head signal that is the same as the current head", "l1_head", newL1Head.Self)
 				continue
 			}
 
 			// Typically get linear extension, but if not, handle a re-org
-			if s.l1Head == newL1Head.Parent {
+			if s.l1Head.Self.Hash == newL1Head.Parent.Hash {
 				s.log.Trace("Linear extension")
-				s.l1Head = newL1Head.Self
+				s.l1Head = newL1Head
 				if s.l1WindowEnd() == newL1Head.Parent {
 					s.l1Window = append(s.l1Window, newL1Head.Self)
 				}
@@ -194,14 +208,14 @@ func (s *state) loop() {
 					s.log.Error("Could not get new safe L2 head when trying to handle a re-org", "err", err)
 					continue
 				}
-				s.l1Head = newL1Head.Self
-				// TODO: Unsafe head here
+				s.l1Head = newL1Head
 				s.l1Window = nil
-				s.l1Base = nextL2Head.L1Origin
-				s.l2SafeHead = nextL2Head.Self
+				s.l2Head = nextL2Head
+				s.l2SafeHead = nextL2Head // TODO: Handle this more carefully
 			}
+
 			// Run step if we are able to
-			if s.l1Head.Number-s.l1Base.Number >= s.Config.SeqWindowSize {
+			if s.l1Head.Self.Number-s.l2Head.L1Origin.Number >= s.Config.SeqWindowSize {
 				requestStep()
 			}
 		case <-stepRequest:
@@ -214,7 +228,7 @@ func (s *state) loop() {
 			if len(s.l1Window) < int(s.Config.SeqWindowSize) {
 				err := s.extendL1Window(context.Background())
 				if err != nil {
-					s.log.Error("Could not extend the cached L1 window", "err", err, "l1Head", s.l1Head, "l1Base", s.l1Base, "window_end", s.l1WindowEnd())
+					s.log.Error("Could not extend the cached L1 window", "err", err, "l1Head", s.l1Head, "window_end", s.l1WindowEnd())
 					continue
 				}
 			}
@@ -223,7 +237,7 @@ func (s *state) loop() {
 			if window, ok := s.sequencingWindow(); ok {
 				s.log.Trace("Have enough cached blocks to run step.")
 				ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-				newL2Head, err := s.output.step(ctx, s.l2SafeHead, s.l2Finalized, s.l2Head, window)
+				newL2Head, err := s.output.step(ctx, s.l2SafeHead, s.l2Finalized, s.l2Head.Self, window)
 				cancel()
 				if err != nil {
 					s.log.Error("Error in running the output step.", "err", err, "l2SafeHead", s.l2SafeHead, "l2Finalized", s.l2Finalized, "window", window)
@@ -233,7 +247,6 @@ func (s *state) loop() {
 					s.l2Head = newL2Head
 				}
 				s.l2SafeHead = newL2Head
-				s.l1Base = s.l1Window[0]
 				s.l1Window = s.l1Window[1:]
 				// TODO: l2Finalized
 			} else {
@@ -241,7 +254,7 @@ func (s *state) loop() {
 			}
 
 			// Immediately run next step if we have enough blocks.
-			if s.l1Head.Number-s.l1Base.Number >= s.Config.SeqWindowSize {
+			if s.l1Head.Self.Number-s.l2Head.L1Origin.Number >= s.Config.SeqWindowSize {
 				requestStep()
 			}
 

--- a/opnode/rollup/driver/state_test.go
+++ b/opnode/rollup/driver/state_test.go
@@ -38,13 +38,13 @@ func (id testID) ID() eth.BlockID {
 	}
 }
 
-type outputHandlerFn func(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, l2Unsafe eth.BlockID, l1Window []eth.BlockID) (eth.BlockID, error)
+type outputHandlerFn func(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.L2BlockRef, error)
 
-func (fn outputHandlerFn) step(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, l2Unsafe eth.BlockID, l1Window []eth.BlockID) (eth.BlockID, error) {
-	return fn(ctx, l2Head, l2Finalized, l2Unsafe, l1Window)
+func (fn outputHandlerFn) step(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.L2BlockRef, error) {
+	return fn(ctx, l2Head, l2Finalized, unsafeL2Head, l1Input)
 }
 
-func (fn outputHandlerFn) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.BlockID, l2Safe eth.BlockID, l1Origin eth.BlockID, includeDeposits bool) (eth.BlockID, *derive.BatchData, error) {
+func (fn outputHandlerFn) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.L2BlockRef, l2Safe eth.BlockID, l1Origin eth.BlockID) (eth.L2BlockRef, *derive.BatchData, error) {
 	panic("Unimplemented")
 }
 
@@ -55,7 +55,7 @@ type outputArgs struct {
 }
 
 type outputReturnArgs struct {
-	l2Head eth.BlockID
+	l2Head eth.L2BlockRef
 	err    error
 }
 
@@ -104,7 +104,7 @@ func advanceL2(t *testing.T, expectedWindow []testID, s *state, src *fakeChainSo
 	for i := range expectedWindow {
 		assert.Equal(t, expectedWindow[i].ID(), args.l1Window[i], "Window elements must match")
 	}
-	outputReturn <- outputReturnArgs{l2Head: src.setL2Head(int(args.l2Head.Number) + 1).Self, err: nil}
+	outputReturn <- outputReturnArgs{l2Head: src.setL2Head(int(args.l2Head.Number) + 1), err: nil}
 }
 
 func reorg__L2(t *testing.T, expectedWindow []testID, s *state, src *fakeChainSource, outputIn chan outputArgs, outputReturn chan outputReturnArgs) {
@@ -115,7 +115,7 @@ func reorg__L2(t *testing.T, expectedWindow []testID, s *state, src *fakeChainSo
 		assert.Equal(t, expectedWindow[i].ID(), args.l1Window[i], "Window elements must match")
 	}
 	src.reorgL2()
-	outputReturn <- outputReturnArgs{l2Head: src.setL2Head(int(args.l2Head.Number) + 1).Self, err: nil}
+	outputReturn <- outputReturnArgs{l2Head: src.setL2Head(int(args.l2Head.Number) + 1), err: nil}
 }
 
 type stateTestCase struct {
@@ -134,8 +134,8 @@ func (tc *stateTestCase) Run(t *testing.T) {
 	// Unbuffered channels to force a sync point between the test and the state loop.
 	outputIn := make(chan outputArgs)
 	outputReturn := make(chan outputReturnArgs)
-	outputHandler := func(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, l2Unsafe eth.BlockID, l1Window []eth.BlockID) (eth.BlockID, error) {
-		outputIn <- outputArgs{l2Head: l2Head, l2Finalized: l2Finalized, l1Window: l1Window}
+	outputHandler := func(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.L2BlockRef, error) {
+		outputIn <- outputArgs{l2Head: l2Head.Self, l2Finalized: l2Finalized, l1Window: l1Input}
 		r := <-outputReturn
 		return r.l2Head, r.err
 	}
@@ -157,8 +157,8 @@ func (tc *stateTestCase) Run(t *testing.T) {
 		step.l2act(t, step.window, state, chainSource, outputIn, outputReturn)
 		<-time.After(5 * time.Millisecond)
 
-		assert.Equal(t, step.l1head.ID(), state.l1Head, "l1 head")
-		assert.Equal(t, step.l2head.ID(), state.l2SafeHead, "l2 head")
+		assert.Equal(t, step.l1head.ID(), state.l1Head.Self, "l1 head")
+		assert.Equal(t, step.l2head.ID(), state.l2SafeHead.Self, "l2 head")
 	}
 }
 

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -23,14 +23,15 @@ type outputImpl struct {
 	Config rollup.Config
 }
 
-func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.BlockID, l2Safe eth.BlockID, l1Origin eth.BlockID, includeDeposits bool) (eth.BlockID, *derive.BatchData, error) {
-	d.log.Info("creating new block", "l2Parent", l2Parent, "l1Origin", l1Origin, "includeDeposits", includeDeposits)
+func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.L2BlockRef, l2Safe eth.BlockID, l1Origin eth.BlockID) (eth.L2BlockRef, *derive.BatchData, error) {
+	d.log.Info("creating new block", "l2Parent", l2Parent)
 	fetchCtx, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
-	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Parent.Hash)
+	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Parent.Self.Hash)
 	if err != nil {
 		return l2Parent, nil, fmt.Errorf("failed to fetch L2 block info of %s: %v", l2Parent, err)
 	}
+
 	l1Info, err := d.dl.FetchL1Info(fetchCtx, l1Origin)
 	if err != nil {
 		return l2Parent, nil, fmt.Errorf("failed to fetch L1 block info of %s: %v", l1Origin, err)
@@ -42,7 +43,11 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 	}
 
 	var receipts types.Receipts
-	if includeDeposits {
+	l2BLockRef, err := derive.BlockReferences(l2Info, &d.Config.Genesis)
+	if err != nil {
+		return l2Parent, nil, fmt.Errorf("failed to derive L2BlockRef from l2Block: %w", err)
+	}
+	if l2BLockRef.L1Origin.Number != l1Origin.Number {
 		receipts, err = d.dl.FetchReceipts(fetchCtx, l1Origin, l1Info.ReceiptHash())
 		if err != nil {
 			return l2Parent, nil, fmt.Errorf("failed to fetch receipts of %s: %v", l1Origin, err)
@@ -54,7 +59,7 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 	}
 	var txns []l2.Data
 	txns = append(txns, l1InfoTx)
-	deposits, err := derive.DeriveDeposits(l2Parent.Number+1, receipts)
+	deposits, err := derive.DeriveDeposits(l2Parent.Self.Number+1, receipts)
 	d.log.Info("Derived deposits", "deposits", deposits, "l2Parent", l2Parent, "l1Origin", l1Origin)
 	if err != nil {
 		return l2Parent, nil, fmt.Errorf("failed to derive deposits: %v", err)
@@ -71,7 +76,7 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 		NoTxPool:              false,
 	}
 	fc := l2.ForkchoiceState{
-		HeadBlockHash:      l2Parent.Hash,
+		HeadBlockHash:      l2Parent.Self.Hash,
 		SafeBlockHash:      l2Safe.Hash,
 		FinalizedBlockHash: l2Finalized.Hash,
 	}
@@ -84,18 +89,18 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 		BatchV1: derive.BatchV1{
 			Epoch:        rollup.Epoch(l1Info.NumberU64()),
 			Timestamp:    uint64(payload.Timestamp),
-			Transactions: payload.Transactions[depositStart:],
+			Transactions: payload.TransactionsField[depositStart:],
 		},
 	}
-
-	return payload.ID(), batch, nil
+	ref, err := derive.BlockReferences(payload, &d.Config.Genesis)
+	return ref, batch, err
 }
 
 // DriverStep derives and processes one or more L2 blocks from the given sequencing window of L1 blocks.
 // An incomplete sequencing window will result in an incomplete L2 chain if so.
 //
 // After the step completes it returns the block ID of the last processed L2 block, even if an error occurs.
-func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (out eth.BlockID, err error) {
+func (d *outputImpl) step(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (out eth.L2BlockRef, err error) {
 	// Sanity Checks
 	if len(l1Input) == 0 {
 		return l2Head, fmt.Errorf("empty L1 sequencing window on L2 %s", l2Head)
@@ -111,7 +116,7 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized e
 	epoch := rollup.Epoch(l1Input[0].Number)
 	fetchCtx, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
-	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Head.Hash)
+	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Head.Self.Hash)
 	if err != nil {
 		return l2Head, fmt.Errorf("failed to fetch L2 block info of %s: %w", l2Head, err)
 	}
@@ -127,7 +132,7 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized e
 	if err != nil {
 		return l2Head, fmt.Errorf("failed to fetch receipts of %s: %w", l1Input[0], err)
 	}
-	deposits, err := derive.DeriveDeposits(l2Head.Number+1, receipts)
+	deposits, err := derive.DeriveDeposits(l2Head.Self.Number+1, receipts)
 	if err != nil {
 		return l2Head, fmt.Errorf("failed to derive deposits: %w", err)
 	}
@@ -148,11 +153,11 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized e
 
 	// Note: SafeBlockHash currently needs to be set b/c of Geth
 	fc := l2.ForkchoiceState{
-		HeadBlockHash:      l2Head.Hash,
-		SafeBlockHash:      l2Head.Hash,
+		HeadBlockHash:      l2Head.Self.Hash,
+		SafeBlockHash:      l2Head.Self.Hash,
 		FinalizedBlockHash: l2Finalized.Hash,
 	}
-	updateUnsafeHead := unsafeL2Head.Hash == l2Head.Hash // If unsafe head is the same as the safe head, keep it up to date
+	updateUnsafeHead := unsafeL2Head.Hash == l2Head.Self.Hash // If unsafe head is the same as the safe head, keep it up to date
 	// Execute each L2 block in the epoch
 	last := l2Head
 	for i, batch := range batches {
@@ -174,10 +179,14 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized e
 		if err != nil {
 			return last, fmt.Errorf("failed to extend L2 chain at block %d/%d of epoch %d: %w", i, len(batches), epoch, err)
 		}
-		last = payload.ID()
+		newLast, err := derive.BlockReferences(payload, &d.Config.Genesis)
+		if err != nil {
+			return last, fmt.Errorf("failed to derive block references: %w", err)
+		}
+		last = newLast
 		// TODO(Joshua): Update this to handle verifiers + sequencers
-		fc.HeadBlockHash = last.Hash
-		fc.SafeBlockHash = last.Hash
+		fc.HeadBlockHash = last.Self.Hash
+		fc.SafeBlockHash = last.Self.Hash
 	}
 
 	return last, nil


### PR DESCRIPTION
**Description**
This removes having to separately keep track of L1Origin and L1Base.
This is nice because those name are confusing and separately used
and it means less information to keep track of.


