### PR TITLE
opnode: New blockref format

### DIFF
--- a/opnode/eth/heads.go
+++ b/opnode/eth/heads.go
@@ -27,14 +27,12 @@ func WatchHeadChanges(ctx context.Context, src NewHeadSource, fn HeadSignalFn) (
 		for {
 			select {
 			case header := <-headChanges:
-				hash := header.Hash()
-				height := header.Number.Uint64()
-				self := BlockID{Hash: hash, Number: height}
-				parent := BlockID{}
-				if height > 0 {
-					parent = BlockID{Hash: header.ParentHash, Number: height - 1}
-				}
-				fn(L1BlockRef{Parent: parent, Self: self})
+				fn(L1BlockRef{
+					Hash:       header.Hash(),
+					Number:     header.Number.Uint64(),
+					ParentHash: header.ParentHash,
+					Time:       header.Time,
+				})
 			case err := <-sub.Err():
 				return err
 			case <-ctx.Done():

--- a/opnode/eth/id.go
+++ b/opnode/eth/id.go
@@ -22,32 +22,74 @@ func (id BlockID) TerminalString() string {
 }
 
 type L2BlockRef struct {
-	Self     BlockID `json:"self"`
-	Parent   BlockID `json:"parent"`
-	L1Origin BlockID `json:"l1_origin"`
+	Hash       common.Hash `json:"hash"`
+	Number     uint64      `json:"number"`
+	ParentHash common.Hash `json:"parentHash"`
+	Time       uint64      `json:"timestamp"`
+	L1Origin   BlockID     `json:"l1origin"`
 }
 
 func (id L2BlockRef) String() string {
-	return fmt.Sprintf("%s:%d", id.Self.Hash.String(), id.Self.Number)
+	return fmt.Sprintf("%s:%d", id.Hash.String(), id.Number)
 }
 
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
 func (id L2BlockRef) TerminalString() string {
-	return fmt.Sprintf("%s:%d", id.Self.Hash.TerminalString(), id.Self.Number)
+	return fmt.Sprintf("%s:%d", id.Hash.TerminalString(), id.Number)
 }
 
 type L1BlockRef struct {
-	Self   BlockID `json:"self"`
-	Parent BlockID `json:"parent"`
+	Hash       common.Hash `json:"hash"`
+	Number     uint64      `json:"number"`
+	ParentHash common.Hash `json:"parentHash"`
+	Time       uint64      `json:"timestamp"`
 }
 
 func (id L1BlockRef) String() string {
-	return fmt.Sprintf("%s:%d", id.Self.Hash.String(), id.Self.Number)
+	return fmt.Sprintf("%s:%d", id.Hash.String(), id.Number)
 }
 
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
 func (id L1BlockRef) TerminalString() string {
-	return fmt.Sprintf("%s:%d", id.Self.Hash.TerminalString(), id.Self.Number)
+	return fmt.Sprintf("%s:%d", id.Hash.TerminalString(), id.Number)
+}
+
+func (id L1BlockRef) Id() BlockID {
+	return BlockID{
+		Hash:   id.Hash,
+		Number: id.Number,
+	}
+}
+
+func (id L1BlockRef) ParentId() BlockID {
+	n := id.Id().Number
+	// Saturate at 0 with subtraction
+	if n > 0 {
+		n -= 1
+	}
+	return BlockID{
+		Hash:   id.ParentHash,
+		Number: n,
+	}
+}
+
+func (id L2BlockRef) Id() BlockID {
+	return BlockID{
+		Hash:   id.Hash,
+		Number: id.Number,
+	}
+}
+
+func (id L2BlockRef) ParentId() BlockID {
+	n := id.Id().Number
+	// Saturate at 0 with subtraction
+	if n > 0 {
+		n -= 1
+	}
+	return BlockID{
+		Hash:   id.ParentHash,
+		Number: n,
+	}
 }

--- a/opnode/l1/source.go
+++ b/opnode/l1/source.go
@@ -125,7 +125,7 @@ func (s Source) L1Range(ctx context.Context, begin eth.BlockID) ([]eth.BlockID, 
 	if canonicalBegin, err := s.L1BlockRefByNumber(ctx, begin.Number); err != nil {
 		return nil, fmt.Errorf("failed to fetch L1 block %v %v: %w", begin.Number, begin.Hash, err)
 	} else {
-		if canonicalBegin.Self != begin {
+		if canonicalBegin.Self.Hash != begin.Hash {
 			return nil, fmt.Errorf("Re-org at begin block. Expected: %v. Actual: %v", begin, canonicalBegin.Self)
 		}
 	}

--- a/opnode/l1/source.go
+++ b/opnode/l1/source.go
@@ -108,14 +108,12 @@ func (s Source) l1BlockRefByNumber(ctx context.Context, number *big.Int) (eth.L1
 		// w%: wrap the error, we still need to detect if a canonical block is not found, a.k.a. end of chain.
 		return eth.L1BlockRef{}, fmt.Errorf("failed to determine block-hash of height %v, could not get header: %w", number, err)
 	}
-	l1Num := header.Number.Uint64()
-	parentNum := l1Num
-	if parentNum > 0 {
-		parentNum -= 1
-	}
+
 	return eth.L1BlockRef{
-		Self:   eth.BlockID{Hash: header.Hash(), Number: l1Num},
-		Parent: eth.BlockID{Hash: header.ParentHash, Number: parentNum},
+		Hash:       header.Hash(),
+		Number:     header.Number.Uint64(),
+		ParentHash: header.ParentHash,
+		Time:       header.Time,
 	}, nil
 }
 
@@ -125,8 +123,8 @@ func (s Source) L1Range(ctx context.Context, begin eth.BlockID) ([]eth.BlockID, 
 	if canonicalBegin, err := s.L1BlockRefByNumber(ctx, begin.Number); err != nil {
 		return nil, fmt.Errorf("failed to fetch L1 block %v %v: %w", begin.Number, begin.Hash, err)
 	} else {
-		if canonicalBegin.Self.Hash != begin.Hash {
-			return nil, fmt.Errorf("Re-org at begin block. Expected: %v. Actual: %v", begin, canonicalBegin.Self)
+		if canonicalBegin.Hash != begin.Hash {
+			return nil, fmt.Errorf("Re-org at begin block. Expected: %v. Actual: %v", begin, canonicalBegin)
 		}
 	}
 
@@ -136,8 +134,8 @@ func (s Source) L1Range(ctx context.Context, begin eth.BlockID) ([]eth.BlockID, 
 	}
 	maxBlocks := MaxBlocksInL1Range
 	// Cap maxBlocks if there are less than maxBlocks between `begin` and the head of the chain.
-	if l1head.Self.Number-begin.Number <= maxBlocks {
-		maxBlocks = l1head.Self.Number - begin.Number
+	if l1head.Number-begin.Number <= maxBlocks {
+		maxBlocks = l1head.Number - begin.Number
 	}
 
 	if maxBlocks == 0 {
@@ -153,11 +151,11 @@ func (s Source) L1Range(ctx context.Context, begin eth.BlockID) ([]eth.BlockID, 
 			return nil, fmt.Errorf("failed to fetch L1 block %v: %w", i, err)
 		}
 		// TODO(Joshua): Look into why this fails around the genesis block
-		if n.Parent.Number != 0 && n.Parent.Hash != prevHash {
+		if n.Number != 1 && n.ParentHash != prevHash {
 			return nil, errors.New("re-organization occurred while attempting to get l1 range")
 		}
-		prevHash = n.Self.Hash
-		res = append(res, n.Self)
+		prevHash = n.Hash
+		res = append(res, n.Id())
 	}
 
 	return res, nil

--- a/opnode/l2/api.go
+++ b/opnode/l2/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 )
 
@@ -88,26 +89,58 @@ type Data = hexutil.Bytes
 type PayloadID = hexutil.Bytes
 
 type ExecutionPayload struct {
-	ParentHash    common.Hash     `json:"parentHash"`
-	FeeRecipient  common.Address  `json:"feeRecipient"`
-	StateRoot     Bytes32         `json:"stateRoot"`
-	ReceiptsRoot  Bytes32         `json:"receiptsRoot"`
-	LogsBloom     Bytes256        `json:"logsBloom"`
-	Random        Bytes32         `json:"random"`
-	BlockNumber   Uint64Quantity  `json:"blockNumber"`
-	GasLimit      Uint64Quantity  `json:"gasLimit"`
-	GasUsed       Uint64Quantity  `json:"gasUsed"`
-	Timestamp     Uint64Quantity  `json:"timestamp"`
-	ExtraData     BytesMax32      `json:"extraData"`
-	BaseFeePerGas Uint256Quantity `json:"baseFeePerGas"`
-	BlockHash     common.Hash     `json:"blockHash"`
+	ParentHashField common.Hash     `json:"parentHash"`
+	FeeRecipient    common.Address  `json:"feeRecipient"`
+	StateRoot       Bytes32         `json:"stateRoot"`
+	ReceiptsRoot    Bytes32         `json:"receiptsRoot"`
+	LogsBloom       Bytes256        `json:"logsBloom"`
+	Random          Bytes32         `json:"random"`
+	BlockNumber     Uint64Quantity  `json:"blockNumber"`
+	GasLimit        Uint64Quantity  `json:"gasLimit"`
+	GasUsed         Uint64Quantity  `json:"gasUsed"`
+	Timestamp       Uint64Quantity  `json:"timestamp"`
+	ExtraData       BytesMax32      `json:"extraData"`
+	BaseFeePerGas   Uint256Quantity `json:"baseFeePerGas"`
+	BlockHash       common.Hash     `json:"blockHash"`
 	// Array of transaction objects, each object is a byte list (DATA) representing
 	// TransactionType || TransactionPayload or LegacyTransaction as defined in EIP-2718
-	Transactions []Data `json:"transactions"`
+	TransactionsField []Data `json:"transactions"`
 }
 
 func (payload *ExecutionPayload) ID() eth.BlockID {
 	return eth.BlockID{Hash: payload.BlockHash, Number: uint64(payload.BlockNumber)}
+}
+
+// Implement block interface to enable derive.BlockReferences over a payload
+// type Block interface {
+// 	Hash() common.Hash
+// 	NumberU64() uint64
+// 	ParentHash() common.Hash
+// 	Transactions() types.Transactions
+// }
+
+func (payload *ExecutionPayload) Hash() common.Hash {
+	return payload.BlockHash
+}
+
+func (payload *ExecutionPayload) NumberU64() uint64 {
+	return uint64(payload.BlockNumber)
+}
+
+func (payload *ExecutionPayload) ParentHash() common.Hash {
+	return payload.ParentHashField
+}
+
+func (payload *ExecutionPayload) Transactions() types.Transactions {
+	res := make([]*types.Transaction, len(payload.TransactionsField))
+	for i, t := range payload.TransactionsField {
+		res[i] = new(types.Transaction)
+		err := res[i].UnmarshalBinary(t)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return res
 }
 
 type PayloadAttributes struct {

--- a/opnode/l2/api.go
+++ b/opnode/l2/api.go
@@ -127,6 +127,10 @@ func (payload *ExecutionPayload) NumberU64() uint64 {
 	return uint64(payload.BlockNumber)
 }
 
+func (payload *ExecutionPayload) Time() uint64 {
+	return uint64(payload.Timestamp)
+}
+
 func (payload *ExecutionPayload) ParentHash() common.Hash {
 	return payload.ParentHashField
 }

--- a/opnode/node/node.go
+++ b/opnode/node/node.go
@@ -156,7 +156,7 @@ func (c *OpNode) Start(ctx context.Context) error {
 		for {
 			select {
 			case l1Head := <-l1Heads:
-				c.log.Info("New L1 head", "head", l1Head.Self, "parent", l1Head.Parent)
+				c.log.Info("New L1 head", "head", l1Head, "parent", l1Head.ParentHash)
 			// TODO: maybe log other info on interval or other chain events (individual engines also log things)
 			case <-c.done:
 				c.log.Info("Closing OpNode")

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -51,8 +51,8 @@ type L2Chain interface {
 }
 
 type outputInterface interface {
-	step(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.BlockID, error)
-	newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.BlockID, l2Safe eth.BlockID, l1Origin eth.BlockID, includeDeposits bool) (eth.BlockID, *derive.BatchData, error)
+	step(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.L2BlockRef, error)
+	newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.L2BlockRef, l2Safe eth.BlockID, l1Origin eth.BlockID) (eth.L2BlockRef, *derive.BatchData, error)
 }
 
 func NewDriver(cfg rollup.Config, l2 *l2.Source, l1 *l1.Source, log log.Logger, submitter BatchSubmitter, sequencer bool) *Driver {

--- a/opnode/rollup/driver/fake_chain.go
+++ b/opnode/rollup/driver/fake_chain.go
@@ -30,7 +30,8 @@ func fakeL1Block(self rune, parent rune, num uint64) eth.L1BlockRef {
 	if num != 0 {
 		parentID = fakeID(parent, num-1)
 	}
-	return eth.L1BlockRef{Self: fakeID(self, num), Parent: parentID}
+	id := fakeID(self, num)
+	return eth.L1BlockRef{Hash: id.Hash, Number: id.Number, ParentHash: parentID.Hash}
 }
 
 func fakeL2Block(self rune, parent rune, l1parent eth.BlockID, num uint64) eth.L2BlockRef {
@@ -38,7 +39,9 @@ func fakeL2Block(self rune, parent rune, l1parent eth.BlockID, num uint64) eth.L
 	if num != 0 {
 		parentID = fakeID(parent, num-1)
 	}
-	return eth.L2BlockRef{Self: fakeID(self, num), Parent: parentID, L1Origin: l1parent}
+	id := fakeID(self, num)
+
+	return eth.L2BlockRef{Hash: id.Hash, Number: id.Number, ParentHash: parentID.Hash, L1Origin: l1parent}
 }
 
 func chainL1(offset uint64, ids string) (out []eth.L1BlockRef) {
@@ -53,7 +56,7 @@ func chainL1(offset uint64, ids string) (out []eth.L1BlockRef) {
 func chainL2(l1 []eth.L1BlockRef, ids string) (out []eth.L2BlockRef) {
 	var prevID rune
 	for i, id := range ids {
-		out = append(out, fakeL2Block(id, prevID, l1[i].Self, uint64(i)))
+		out = append(out, fakeL2Block(id, prevID, l1[i].Id(), uint64(i)))
 		prevID = id
 	}
 	return
@@ -93,9 +96,9 @@ func (m *fakeChainSource) L1Range(ctx context.Context, base eth.BlockID) ([]eth.
 	found := false
 	for i, b := range m.l1s[m.l1reorg] {
 		if found {
-			out = append(out, b.Self)
+			out = append(out, b.Id())
 		}
-		if b.Self == base {
+		if b.Id() == base {
 			found = true
 		}
 		if i == m.l1head {
@@ -144,7 +147,7 @@ func (m *fakeChainSource) L2BlockRefByNumber(ctx context.Context, l2Num *big.Int
 func (m *fakeChainSource) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
 	m.log.Trace("L2BlockRefByHash", "l2Hash", l2Hash, "l2Head", m.l2head, "reorg", m.l2reorg)
 	for i, bl := range m.l2s[m.l2reorg] {
-		if bl.Self.Hash == l2Hash {
+		if bl.Hash == l2Hash {
 			return m.L2BlockRefByNumber(ctx, big.NewInt(int64(i)))
 		}
 	}

--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -13,13 +13,11 @@ import (
 
 type state struct {
 	// Chain State
-	l1Head      eth.BlockID   // Latest recorded head of the L1 Chain
-	l2Head      eth.BlockID   // L2 Unsafe Head
-	l1Origin    eth.BlockID   // L1 Origin of the L2 Unsafe head. For sequencing only.
-	l2SafeHead  eth.BlockID   // L2 Safe Head - this is the head of the L2 chain as derived from L1 (thus it is Sequencer window blocks behind)
-	l1Base      eth.BlockID   // L1 Parent of L2 Safe Head block
-	l2Finalized eth.BlockID   // L2 Block that will never be reversed
-	l1Window    []eth.BlockID // l1Window buffers the next L1 block IDs to derive new L2 blocks from, with increasing block height.
+	l1Head      eth.L1BlockRef // Latest recorded head of the L1 Chain
+	l2Head      eth.L2BlockRef // L2 Unsafe Head
+	l2SafeHead  eth.L2BlockRef // L2 Safe Head - this is the head of the L2 chain as derived from L1 (thus it is Sequencer window blocks behind)
+	l2Finalized eth.BlockID    // L2 Block that will never be reversed
+	l1Window    []eth.BlockID  // l1Window buffers the next L1 block IDs to derive new L2 blocks from, with increasing block height.
 
 	// Rollup config
 	Config    rollup.Config
@@ -59,12 +57,12 @@ func (s *state) Start(ctx context.Context, l1Heads <-chan eth.L1BlockRef) error 
 		return err
 	}
 
-	//  TODO: Don't start everything from L2 heads
-	s.l1Head = l1Head.Self
-	s.l1Origin = s.l1Head
-	s.l2Head = l2Head.Self // TODO: Makes sense?
-	s.l2SafeHead = l2Head.Self
-	s.l1Base = l2Head.L1Origin
+	// TODO:
+	// 1. Pull safehead from sync-start algorithm
+	// 2. Check if heads are below genesis & if so, bump to genesis.
+	s.l1Head = l1Head
+	s.l2Head = l2Head
+	s.l2SafeHead = l2Head
 	s.l1Heads = l1Heads
 
 	go s.loop()
@@ -80,7 +78,7 @@ func (s *state) Close() error {
 // This is either the last block of the window, or the L1 base block if the window is not populated.
 func (s *state) l1WindowEnd() eth.BlockID {
 	if len(s.l1Window) == 0 {
-		return s.l1Base
+		return s.l2Head.L1Origin
 	}
 	return s.l1Window[len(s.l1Window)-1]
 }
@@ -104,6 +102,19 @@ func (s *state) sequencingWindow() ([]eth.BlockID, bool) {
 		return nil, false
 	}
 	return s.l1Window[:int(s.Config.SeqWindowSize)], true
+}
+
+func (s *state) findNextL1Origin(ctx context.Context) (eth.BlockID, error) {
+	return s.l1Head.Self, nil // Temporary until timestamps are working correctly
+	// [prev L2 + blocktime, L1 Bock)
+	// currentL1Origin := s.l2Head.L1Origin
+	// s.log.Info("Find next l1Origin", "l2Head", s.l2Head, "l1Origin", currentL1Origin)
+	// if s.l2Head.Time+int64(s.Config.BlockTime) >= currentL1Origin.Time {
+	// 	ref, err := s.l1.L1BlockRefByNumber(ctx, currentL1Origin.Number+1)
+	// 	s.log.Info("Lookuing up new L1 Origin", "nextL1Origin", ref)
+	// 	return ref.Self, err
+	// }
+	// return currentL1Origin, nil
 }
 
 func (s *state) loop() {
@@ -139,20 +150,18 @@ func (s *state) loop() {
 		case <-s.done:
 			return
 		case <-l2BlockCreation:
-			// 1. Check if new epoch (new L1 head)
-			firstOfEpoch := false
-			if s.l1Head != s.l1Origin {
-				firstOfEpoch = true
-				s.l1Origin = s.l1Head
+			nextOrigin, err := s.findNextL1Origin(context.Background())
+			if err != nil {
+				continue
 			}
 			// Don't produce blocks until past the L1 genesis
-			if s.l1Origin.Number <= s.Config.Genesis.L1.Number {
+			if nextOrigin.Number <= s.Config.Genesis.L1.Number {
 				continue
 			}
 			// 2. Ask output to create new block
-			newUnsafeL2Head, batch, err := s.output.newBlock(context.Background(), s.l2Finalized, s.l2Head, s.l2SafeHead, s.l1Origin, firstOfEpoch)
+			newUnsafeL2Head, batch, err := s.output.newBlock(context.Background(), s.l2Finalized, s.l2Head, s.l2SafeHead.Self, nextOrigin)
 			if err != nil {
-				s.log.Error("Could not extend chain as sequencer", "err", err, "l2UnsafeHead", s.l2Head, "l1Origin", s.l1Origin)
+				s.log.Error("Could not extend chain as sequencer", "err", err, "l2UnsafeHead", s.l2Head, "l1Origin", nextOrigin)
 				continue
 			}
 			// 3. Update unsafe l2 head + epoch
@@ -169,15 +178,15 @@ func (s *state) loop() {
 		case newL1Head := <-s.l1Heads:
 			s.log.Trace("Received new L1 Head", "new_head", newL1Head.Self, "old_head", s.l1Head)
 			// Check if we have a stutter step. May be due to a L1 Poll operation.
-			if s.l1Head == newL1Head.Self {
+			if s.l1Head.Self.Hash == newL1Head.Self.Hash {
 				log.Trace("Received L1 head signal that is the same as the current head", "l1_head", newL1Head.Self)
 				continue
 			}
 
 			// Typically get linear extension, but if not, handle a re-org
-			if s.l1Head == newL1Head.Parent {
+			if s.l1Head.Self.Hash == newL1Head.Parent.Hash {
 				s.log.Trace("Linear extension")
-				s.l1Head = newL1Head.Self
+				s.l1Head = newL1Head
 				if s.l1WindowEnd() == newL1Head.Parent {
 					s.l1Window = append(s.l1Window, newL1Head.Self)
 				}
@@ -194,14 +203,14 @@ func (s *state) loop() {
 					s.log.Error("Could not get new safe L2 head when trying to handle a re-org", "err", err)
 					continue
 				}
-				s.l1Head = newL1Head.Self
-				// TODO: Unsafe head here
+				s.l1Head = newL1Head
 				s.l1Window = nil
-				s.l1Base = nextL2Head.L1Origin
-				s.l2SafeHead = nextL2Head.Self
+				s.l2Head = nextL2Head
+				s.l2SafeHead = nextL2Head // TODO: Handle this more carefully
 			}
+
 			// Run step if we are able to
-			if s.l1Head.Number-s.l1Base.Number >= s.Config.SeqWindowSize {
+			if s.l1Head.Self.Number-s.l2Head.L1Origin.Number >= s.Config.SeqWindowSize {
 				requestStep()
 			}
 		case <-stepRequest:
@@ -214,7 +223,7 @@ func (s *state) loop() {
 			if len(s.l1Window) < int(s.Config.SeqWindowSize) {
 				err := s.extendL1Window(context.Background())
 				if err != nil {
-					s.log.Error("Could not extend the cached L1 window", "err", err, "l1Head", s.l1Head, "l1Base", s.l1Base, "window_end", s.l1WindowEnd())
+					s.log.Error("Could not extend the cached L1 window", "err", err, "l1Head", s.l1Head, "window_end", s.l1WindowEnd())
 					continue
 				}
 			}
@@ -223,7 +232,7 @@ func (s *state) loop() {
 			if window, ok := s.sequencingWindow(); ok {
 				s.log.Trace("Have enough cached blocks to run step.")
 				ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-				newL2Head, err := s.output.step(ctx, s.l2SafeHead, s.l2Finalized, s.l2Head, window)
+				newL2Head, err := s.output.step(ctx, s.l2SafeHead, s.l2Finalized, s.l2Head.Self, window)
 				cancel()
 				if err != nil {
 					s.log.Error("Error in running the output step.", "err", err, "l2SafeHead", s.l2SafeHead, "l2Finalized", s.l2Finalized, "window", window)
@@ -233,7 +242,6 @@ func (s *state) loop() {
 					s.l2Head = newL2Head
 				}
 				s.l2SafeHead = newL2Head
-				s.l1Base = s.l1Window[0]
 				s.l1Window = s.l1Window[1:]
 				// TODO: l2Finalized
 			} else {
@@ -241,7 +249,7 @@ func (s *state) loop() {
 			}
 
 			// Immediately run next step if we have enough blocks.
-			if s.l1Head.Number-s.l1Base.Number >= s.Config.SeqWindowSize {
+			if s.l1Head.Self.Number-s.l2Head.L1Origin.Number >= s.Config.SeqWindowSize {
 				requestStep()
 			}
 

--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -105,7 +105,7 @@ func (s *state) sequencingWindow() ([]eth.BlockID, bool) {
 }
 
 func (s *state) findNextL1Origin(ctx context.Context) (eth.BlockID, error) {
-	return s.l1Head.Self, nil // Temporary until timestamps are working correctly
+	return s.l1Head.Id(), nil // Temporary until timestamps are working correctly
 	// [prev L2 + blocktime, L1 Bock)
 	// currentL1Origin := s.l2Head.L1Origin
 	// s.log.Info("Find next l1Origin", "l2Head", s.l2Head, "l1Origin", currentL1Origin)
@@ -159,7 +159,7 @@ func (s *state) loop() {
 				continue
 			}
 			// 2. Ask output to create new block
-			newUnsafeL2Head, batch, err := s.output.newBlock(context.Background(), s.l2Finalized, s.l2Head, s.l2SafeHead.Self, nextOrigin)
+			newUnsafeL2Head, batch, err := s.output.newBlock(context.Background(), s.l2Finalized, s.l2Head, s.l2SafeHead.Id(), nextOrigin)
 			if err != nil {
 				s.log.Error("Could not extend chain as sequencer", "err", err, "l2UnsafeHead", s.l2Head, "l1Origin", nextOrigin)
 				continue
@@ -176,29 +176,29 @@ func (s *state) loop() {
 			}()
 
 		case newL1Head := <-s.l1Heads:
-			s.log.Trace("Received new L1 Head", "new_head", newL1Head.Self, "old_head", s.l1Head)
+			s.log.Trace("Received new L1 Head", "new_head", newL1Head, "old_head", s.l1Head)
 			// Check if we have a stutter step. May be due to a L1 Poll operation.
-			if s.l1Head.Self.Hash == newL1Head.Self.Hash {
-				log.Trace("Received L1 head signal that is the same as the current head", "l1_head", newL1Head.Self)
+			if s.l1Head.Hash == newL1Head.Hash {
+				log.Trace("Received L1 head signal that is the same as the current head", "l1_head", newL1Head)
 				continue
 			}
 
 			// Typically get linear extension, but if not, handle a re-org
-			if s.l1Head.Self.Hash == newL1Head.Parent.Hash {
+			if s.l1Head.Hash == newL1Head.ParentHash {
 				s.log.Trace("Linear extension")
 				s.l1Head = newL1Head
-				if s.l1WindowEnd() == newL1Head.Parent {
-					s.l1Window = append(s.l1Window, newL1Head.Self)
+				if s.l1WindowEnd().Hash == newL1Head.ParentHash {
+					s.l1Window = append(s.l1Window, newL1Head.Id())
 				}
 			} else {
-				s.log.Warn("L1 Head signal indicates an L1 re-org", "old_l1_head", s.l1Head, "new_l1_head_parent", newL1Head.Parent, "new_l1_head", newL1Head.Self)
+				s.log.Warn("L1 Head signal indicates an L1 re-org", "old_l1_head", s.l1Head, "new_l1_head_parent", newL1Head.ParentHash, "new_l1_head", newL1Head)
 				// TODO(Joshua): Fix having to make this call when being careful about the exact state
 				l2Head, err := s.l2.L2BlockRefByNumber(context.Background(), nil)
 				if err != nil {
 					s.log.Error("Could not get fetch L2 head when trying to handle a re-org", "err", err)
 					continue
 				}
-				nextL2Head, err := sync.FindSafeL2Head(ctx, l2Head.Self, s.l1, s.l2, &s.Config.Genesis)
+				nextL2Head, err := sync.FindSafeL2Head(ctx, l2Head.Id(), s.l1, s.l2, &s.Config.Genesis)
 				if err != nil {
 					s.log.Error("Could not get new safe L2 head when trying to handle a re-org", "err", err)
 					continue
@@ -210,7 +210,7 @@ func (s *state) loop() {
 			}
 
 			// Run step if we are able to
-			if s.l1Head.Self.Number-s.l2Head.L1Origin.Number >= s.Config.SeqWindowSize {
+			if s.l1Head.Number-s.l2Head.L1Origin.Number >= s.Config.SeqWindowSize {
 				requestStep()
 			}
 		case <-stepRequest:
@@ -232,7 +232,7 @@ func (s *state) loop() {
 			if window, ok := s.sequencingWindow(); ok {
 				s.log.Trace("Have enough cached blocks to run step.")
 				ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-				newL2Head, err := s.output.step(ctx, s.l2SafeHead, s.l2Finalized, s.l2Head.Self, window)
+				newL2Head, err := s.output.step(ctx, s.l2SafeHead, s.l2Finalized, s.l2Head.Id(), window)
 				cancel()
 				if err != nil {
 					s.log.Error("Error in running the output step.", "err", err, "l2SafeHead", s.l2SafeHead, "l2Finalized", s.l2Finalized, "window", window)
@@ -249,7 +249,7 @@ func (s *state) loop() {
 			}
 
 			// Immediately run next step if we have enough blocks.
-			if s.l1Head.Self.Number-s.l2Head.L1Origin.Number >= s.Config.SeqWindowSize {
+			if s.l1Head.Number-s.l2Head.L1Origin.Number >= s.Config.SeqWindowSize {
 				requestStep()
 			}
 

--- a/opnode/rollup/driver/state_test.go
+++ b/opnode/rollup/driver/state_test.go
@@ -135,7 +135,7 @@ func (tc *stateTestCase) Run(t *testing.T) {
 	outputIn := make(chan outputArgs)
 	outputReturn := make(chan outputReturnArgs)
 	outputHandler := func(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.L2BlockRef, error) {
-		outputIn <- outputArgs{l2Head: l2Head.Self, l2Finalized: l2Finalized, l1Window: l1Input}
+		outputIn <- outputArgs{l2Head: l2Head.Id(), l2Finalized: l2Finalized, l1Window: l1Input}
 		r := <-outputReturn
 		return r.l2Head, r.err
 	}
@@ -157,8 +157,8 @@ func (tc *stateTestCase) Run(t *testing.T) {
 		step.l2act(t, step.window, state, chainSource, outputIn, outputReturn)
 		<-time.After(5 * time.Millisecond)
 
-		assert.Equal(t, step.l1head.ID(), state.l1Head.Self, "l1 head")
-		assert.Equal(t, step.l2head.ID(), state.l2SafeHead.Self, "l2 head")
+		assert.Equal(t, step.l1head.ID(), state.l1Head.Id(), "l1 head")
+		assert.Equal(t, step.l2head.ID(), state.l2SafeHead.Id(), "l2 head")
 	}
 }
 

--- a/opnode/rollup/driver/state_test.go
+++ b/opnode/rollup/driver/state_test.go
@@ -38,13 +38,13 @@ func (id testID) ID() eth.BlockID {
 	}
 }
 
-type outputHandlerFn func(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, l2Unsafe eth.BlockID, l1Window []eth.BlockID) (eth.BlockID, error)
+type outputHandlerFn func(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.L2BlockRef, error)
 
-func (fn outputHandlerFn) step(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, l2Unsafe eth.BlockID, l1Window []eth.BlockID) (eth.BlockID, error) {
-	return fn(ctx, l2Head, l2Finalized, l2Unsafe, l1Window)
+func (fn outputHandlerFn) step(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.L2BlockRef, error) {
+	return fn(ctx, l2Head, l2Finalized, unsafeL2Head, l1Input)
 }
 
-func (fn outputHandlerFn) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.BlockID, l2Safe eth.BlockID, l1Origin eth.BlockID, includeDeposits bool) (eth.BlockID, *derive.BatchData, error) {
+func (fn outputHandlerFn) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.L2BlockRef, l2Safe eth.BlockID, l1Origin eth.BlockID) (eth.L2BlockRef, *derive.BatchData, error) {
 	panic("Unimplemented")
 }
 
@@ -55,7 +55,7 @@ type outputArgs struct {
 }
 
 type outputReturnArgs struct {
-	l2Head eth.BlockID
+	l2Head eth.L2BlockRef
 	err    error
 }
 
@@ -104,7 +104,7 @@ func advanceL2(t *testing.T, expectedWindow []testID, s *state, src *fakeChainSo
 	for i := range expectedWindow {
 		assert.Equal(t, expectedWindow[i].ID(), args.l1Window[i], "Window elements must match")
 	}
-	outputReturn <- outputReturnArgs{l2Head: src.setL2Head(int(args.l2Head.Number) + 1).Self, err: nil}
+	outputReturn <- outputReturnArgs{l2Head: src.setL2Head(int(args.l2Head.Number) + 1), err: nil}
 }
 
 func reorg__L2(t *testing.T, expectedWindow []testID, s *state, src *fakeChainSource, outputIn chan outputArgs, outputReturn chan outputReturnArgs) {
@@ -115,7 +115,7 @@ func reorg__L2(t *testing.T, expectedWindow []testID, s *state, src *fakeChainSo
 		assert.Equal(t, expectedWindow[i].ID(), args.l1Window[i], "Window elements must match")
 	}
 	src.reorgL2()
-	outputReturn <- outputReturnArgs{l2Head: src.setL2Head(int(args.l2Head.Number) + 1).Self, err: nil}
+	outputReturn <- outputReturnArgs{l2Head: src.setL2Head(int(args.l2Head.Number) + 1), err: nil}
 }
 
 type stateTestCase struct {
@@ -134,8 +134,8 @@ func (tc *stateTestCase) Run(t *testing.T) {
 	// Unbuffered channels to force a sync point between the test and the state loop.
 	outputIn := make(chan outputArgs)
 	outputReturn := make(chan outputReturnArgs)
-	outputHandler := func(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, l2Unsafe eth.BlockID, l1Window []eth.BlockID) (eth.BlockID, error) {
-		outputIn <- outputArgs{l2Head: l2Head, l2Finalized: l2Finalized, l1Window: l1Window}
+	outputHandler := func(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (eth.L2BlockRef, error) {
+		outputIn <- outputArgs{l2Head: l2Head.Self, l2Finalized: l2Finalized, l1Window: l1Input}
 		r := <-outputReturn
 		return r.l2Head, r.err
 	}
@@ -157,8 +157,8 @@ func (tc *stateTestCase) Run(t *testing.T) {
 		step.l2act(t, step.window, state, chainSource, outputIn, outputReturn)
 		<-time.After(5 * time.Millisecond)
 
-		assert.Equal(t, step.l1head.ID(), state.l1Head, "l1 head")
-		assert.Equal(t, step.l2head.ID(), state.l2SafeHead, "l2 head")
+		assert.Equal(t, step.l1head.ID(), state.l1Head.Self, "l1 head")
+		assert.Equal(t, step.l2head.ID(), state.l2SafeHead.Self, "l2 head")
 	}
 }
 

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -27,7 +27,7 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 	d.log.Info("creating new block", "l2Parent", l2Parent)
 	fetchCtx, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
-	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Parent.Self.Hash)
+	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Parent.Hash)
 	if err != nil {
 		return l2Parent, nil, fmt.Errorf("failed to fetch L2 block info of %s: %v", l2Parent, err)
 	}
@@ -59,7 +59,7 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 	}
 	var txns []l2.Data
 	txns = append(txns, l1InfoTx)
-	deposits, err := derive.DeriveDeposits(l2Parent.Self.Number+1, receipts)
+	deposits, err := derive.DeriveDeposits(l2Parent.Number+1, receipts)
 	d.log.Info("Derived deposits", "deposits", deposits, "l2Parent", l2Parent, "l1Origin", l1Origin)
 	if err != nil {
 		return l2Parent, nil, fmt.Errorf("failed to derive deposits: %v", err)
@@ -76,7 +76,7 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 		NoTxPool:              false,
 	}
 	fc := l2.ForkchoiceState{
-		HeadBlockHash:      l2Parent.Self.Hash,
+		HeadBlockHash:      l2Parent.Hash,
 		SafeBlockHash:      l2Safe.Hash,
 		FinalizedBlockHash: l2Finalized.Hash,
 	}
@@ -116,7 +116,7 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.L2BlockRef, l2Finalize
 	epoch := rollup.Epoch(l1Input[0].Number)
 	fetchCtx, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
-	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Head.Self.Hash)
+	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Head.Hash)
 	if err != nil {
 		return l2Head, fmt.Errorf("failed to fetch L2 block info of %s: %w", l2Head, err)
 	}
@@ -132,7 +132,7 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.L2BlockRef, l2Finalize
 	if err != nil {
 		return l2Head, fmt.Errorf("failed to fetch receipts of %s: %w", l1Input[0], err)
 	}
-	deposits, err := derive.DeriveDeposits(l2Head.Self.Number+1, receipts)
+	deposits, err := derive.DeriveDeposits(l2Head.Number+1, receipts)
 	if err != nil {
 		return l2Head, fmt.Errorf("failed to derive deposits: %w", err)
 	}
@@ -153,11 +153,11 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.L2BlockRef, l2Finalize
 
 	// Note: SafeBlockHash currently needs to be set b/c of Geth
 	fc := l2.ForkchoiceState{
-		HeadBlockHash:      l2Head.Self.Hash,
-		SafeBlockHash:      l2Head.Self.Hash,
+		HeadBlockHash:      l2Head.Hash,
+		SafeBlockHash:      l2Head.Hash,
 		FinalizedBlockHash: l2Finalized.Hash,
 	}
-	updateUnsafeHead := unsafeL2Head.Hash == l2Head.Self.Hash // If unsafe head is the same as the safe head, keep it up to date
+	updateUnsafeHead := unsafeL2Head.Hash == l2Head.Hash // If unsafe head is the same as the safe head, keep it up to date
 	// Execute each L2 block in the epoch
 	last := l2Head
 	for i, batch := range batches {
@@ -185,8 +185,8 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.L2BlockRef, l2Finalize
 		}
 		last = newLast
 		// TODO(Joshua): Update this to handle verifiers + sequencers
-		fc.HeadBlockHash = last.Self.Hash
-		fc.SafeBlockHash = last.Self.Hash
+		fc.HeadBlockHash = last.Hash
+		fc.SafeBlockHash = last.Hash
 	}
 
 	return last, nil

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -23,14 +23,15 @@ type outputImpl struct {
 	Config rollup.Config
 }
 
-func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.BlockID, l2Safe eth.BlockID, l1Origin eth.BlockID, includeDeposits bool) (eth.BlockID, *derive.BatchData, error) {
-	d.log.Info("creating new block", "l2Parent", l2Parent, "l1Origin", l1Origin, "includeDeposits", includeDeposits)
+func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Parent eth.L2BlockRef, l2Safe eth.BlockID, l1Origin eth.BlockID) (eth.L2BlockRef, *derive.BatchData, error) {
+	d.log.Info("creating new block", "l2Parent", l2Parent)
 	fetchCtx, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
-	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Parent.Hash)
+	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Parent.Self.Hash)
 	if err != nil {
 		return l2Parent, nil, fmt.Errorf("failed to fetch L2 block info of %s: %v", l2Parent, err)
 	}
+
 	l1Info, err := d.dl.FetchL1Info(fetchCtx, l1Origin)
 	if err != nil {
 		return l2Parent, nil, fmt.Errorf("failed to fetch L1 block info of %s: %v", l1Origin, err)
@@ -42,7 +43,11 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 	}
 
 	var receipts types.Receipts
-	if includeDeposits {
+	l2BLockRef, err := derive.BlockReferences(l2Info, &d.Config.Genesis)
+	if err != nil {
+		return l2Parent, nil, fmt.Errorf("failed to derive L2BlockRef from l2Block: %w", err)
+	}
+	if l2BLockRef.L1Origin.Number != l1Origin.Number {
 		receipts, err = d.dl.FetchReceipts(fetchCtx, l1Origin, l1Info.ReceiptHash())
 		if err != nil {
 			return l2Parent, nil, fmt.Errorf("failed to fetch receipts of %s: %v", l1Origin, err)
@@ -54,7 +59,7 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 	}
 	var txns []l2.Data
 	txns = append(txns, l1InfoTx)
-	deposits, err := derive.DeriveDeposits(l2Parent.Number+1, receipts)
+	deposits, err := derive.DeriveDeposits(l2Parent.Self.Number+1, receipts)
 	d.log.Info("Derived deposits", "deposits", deposits, "l2Parent", l2Parent, "l1Origin", l1Origin)
 	if err != nil {
 		return l2Parent, nil, fmt.Errorf("failed to derive deposits: %v", err)
@@ -71,7 +76,7 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 		NoTxPool:              false,
 	}
 	fc := l2.ForkchoiceState{
-		HeadBlockHash:      l2Parent.Hash,
+		HeadBlockHash:      l2Parent.Self.Hash,
 		SafeBlockHash:      l2Safe.Hash,
 		FinalizedBlockHash: l2Finalized.Hash,
 	}
@@ -84,18 +89,18 @@ func (d *outputImpl) newBlock(ctx context.Context, l2Finalized eth.BlockID, l2Pa
 		BatchV1: derive.BatchV1{
 			Epoch:        rollup.Epoch(l1Info.NumberU64()),
 			Timestamp:    uint64(payload.Timestamp),
-			Transactions: payload.Transactions[depositStart:],
+			Transactions: payload.TransactionsField[depositStart:],
 		},
 	}
-
-	return payload.ID(), batch, nil
+	ref, err := derive.BlockReferences(payload, &d.Config.Genesis)
+	return ref, batch, err
 }
 
 // DriverStep derives and processes one or more L2 blocks from the given sequencing window of L1 blocks.
 // An incomplete sequencing window will result in an incomplete L2 chain if so.
 //
 // After the step completes it returns the block ID of the last processed L2 block, even if an error occurs.
-func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (out eth.BlockID, err error) {
+func (d *outputImpl) step(ctx context.Context, l2Head eth.L2BlockRef, l2Finalized eth.BlockID, unsafeL2Head eth.BlockID, l1Input []eth.BlockID) (out eth.L2BlockRef, err error) {
 	// Sanity Checks
 	if len(l1Input) == 0 {
 		return l2Head, fmt.Errorf("empty L1 sequencing window on L2 %s", l2Head)
@@ -111,7 +116,7 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized e
 	epoch := rollup.Epoch(l1Input[0].Number)
 	fetchCtx, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
-	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Head.Hash)
+	l2Info, err := d.l2.BlockByHash(fetchCtx, l2Head.Self.Hash)
 	if err != nil {
 		return l2Head, fmt.Errorf("failed to fetch L2 block info of %s: %w", l2Head, err)
 	}
@@ -127,7 +132,7 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized e
 	if err != nil {
 		return l2Head, fmt.Errorf("failed to fetch receipts of %s: %w", l1Input[0], err)
 	}
-	deposits, err := derive.DeriveDeposits(l2Head.Number+1, receipts)
+	deposits, err := derive.DeriveDeposits(l2Head.Self.Number+1, receipts)
 	if err != nil {
 		return l2Head, fmt.Errorf("failed to derive deposits: %w", err)
 	}
@@ -148,11 +153,11 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized e
 
 	// Note: SafeBlockHash currently needs to be set b/c of Geth
 	fc := l2.ForkchoiceState{
-		HeadBlockHash:      l2Head.Hash,
-		SafeBlockHash:      l2Head.Hash,
+		HeadBlockHash:      l2Head.Self.Hash,
+		SafeBlockHash:      l2Head.Self.Hash,
 		FinalizedBlockHash: l2Finalized.Hash,
 	}
-	updateUnsafeHead := unsafeL2Head.Hash == l2Head.Hash // If unsafe head is the same as the safe head, keep it up to date
+	updateUnsafeHead := unsafeL2Head.Hash == l2Head.Self.Hash // If unsafe head is the same as the safe head, keep it up to date
 	// Execute each L2 block in the epoch
 	last := l2Head
 	for i, batch := range batches {
@@ -174,10 +179,14 @@ func (d *outputImpl) step(ctx context.Context, l2Head eth.BlockID, l2Finalized e
 		if err != nil {
 			return last, fmt.Errorf("failed to extend L2 chain at block %d/%d of epoch %d: %w", i, len(batches), epoch, err)
 		}
-		last = payload.ID()
+		newLast, err := derive.BlockReferences(payload, &d.Config.Genesis)
+		if err != nil {
+			return last, fmt.Errorf("failed to derive block references: %w", err)
+		}
+		last = newLast
 		// TODO(Joshua): Update this to handle verifiers + sequencers
-		fc.HeadBlockHash = last.Hash
-		fc.SafeBlockHash = last.Hash
+		fc.HeadBlockHash = last.Self.Hash
+		fc.SafeBlockHash = last.Self.Hash
 	}
 
 	return last, nil

--- a/opnode/rollup/sync/start.go
+++ b/opnode/rollup/sync/start.go
@@ -79,21 +79,21 @@ func FindSafeL2Head(ctx context.Context, start eth.BlockID, l1 L1Chain, l2 L2Cha
 			// L1 block not found, keep walking chain
 		} else {
 			// L1 Block found, check if matches & should keep walking the chain
-			if l1header.Self.Hash == n.L1Origin.Hash {
+			if l1header.Hash == n.L1Origin.Hash {
 				return n, nil
 			}
 		}
 
 		// Don't walk past genesis. If we were at the L2 genesis, but could not find the L1 genesis
 		// pointed to from it, we are on the wrong L1 chain.
-		if n.Self.Hash == genesis.L2.Hash || n.Self.Number == genesis.L2.Number {
+		if n.Hash == genesis.L2.Hash || n.Number == genesis.L2.Number {
 			return eth.L2BlockRef{}, WrongChainErr
 		}
 
 		// Pull L2 parent for next iteration
-		n, err = l2.L2BlockRefByHash(ctx, n.Parent.Hash)
+		n, err = l2.L2BlockRefByHash(ctx, n.ParentHash)
 		if err != nil {
-			return eth.L2BlockRef{}, fmt.Errorf("failed to fetch L2 block by hash %v: %w", n.Parent.Hash, err)
+			return eth.L2BlockRef{}, fmt.Errorf("failed to fetch L2 block by hash %v: %w", n.ParentHash, err)
 		}
 		reorgDepth++
 		if reorgDepth >= MaxReorgDepth {

--- a/opnode/rollup/sync/start_test.go
+++ b/opnode/rollup/sync/start_test.go
@@ -23,9 +23,9 @@ func (m *fakeChainSource) L1Range(ctx context.Context, base eth.BlockID) ([]eth.
 	found := false
 	for _, b := range m.L1 {
 		if found {
-			out = append(out, b.Self)
+			out = append(out, b.Id())
 		}
-		if b.Self == base {
+		if b.Id() == base {
 			found = true
 		}
 	}
@@ -63,7 +63,7 @@ func (m *fakeChainSource) L2BlockRefByNumber(ctx context.Context, l2Num *big.Int
 
 func (m *fakeChainSource) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
 	for i, bl := range m.L2 {
-		if bl.Self.Hash == l2Hash {
+		if bl.Hash == l2Hash {
 			return m.L2BlockRefByNumber(ctx, big.NewInt(int64(i)))
 		}
 	}
@@ -84,7 +84,8 @@ func fakeL1Block(self rune, parent rune, num uint64) eth.L1BlockRef {
 	if num != 0 {
 		parentID = fakeID(parent, num-1)
 	}
-	return eth.L1BlockRef{Self: fakeID(self, num), Parent: parentID}
+	id := fakeID(self, num)
+	return eth.L1BlockRef{Hash: id.Hash, Number: id.Number, ParentHash: parentID.Hash}
 }
 
 func fakeL2Block(self rune, parent rune, l1parent eth.BlockID, num uint64) eth.L2BlockRef {
@@ -92,7 +93,8 @@ func fakeL2Block(self rune, parent rune, l1parent eth.BlockID, num uint64) eth.L
 	if num != 0 {
 		parentID = fakeID(parent, num-1)
 	}
-	return eth.L2BlockRef{Self: fakeID(self, num), Parent: parentID, L1Origin: l1parent}
+	id := fakeID(self, num)
+	return eth.L2BlockRef{Hash: id.Hash, Number: id.Number, ParentHash: parentID.Hash, L1Origin: l1parent}
 }
 
 func chainL1(offset uint64, ids string) (out []eth.L1BlockRef) {
@@ -107,7 +109,7 @@ func chainL1(offset uint64, ids string) (out []eth.L1BlockRef) {
 func chainL2(l1 []eth.L1BlockRef, ids string) (out []eth.L2BlockRef) {
 	var prevID rune
 	for i, id := range ids {
-		out = append(out, fakeL2Block(id, prevID, l1[i].Self, uint64(i)))
+		out = append(out, fakeL2Block(id, prevID, l1[i].Id(), uint64(i)))
 		prevID = id
 	}
 	return
@@ -150,7 +152,7 @@ func (c *syncStartTestCase) Run(t *testing.T) {
 	}
 	head, err := msr.L2BlockRefByNumber(context.Background(), nil)
 	require.Nil(t, err)
-	refL2, err := FindSafeL2Head(context.Background(), head.Self, msr, msr, genesis)
+	refL2, err := FindSafeL2Head(context.Background(), head.Id(), msr, msr, genesis)
 
 	if c.ExpectedErr != nil {
 		assert.Error(t, err, "Expecting an error in this test case")
@@ -158,7 +160,7 @@ func (c *syncStartTestCase) Run(t *testing.T) {
 	} else {
 		nextRefL1s, err := msr.L1Range(context.Background(), refL2.L1Origin)
 		require.Nil(t, err)
-		expectedRefL2 := refToRune(refL2.Self)
+		expectedRefL2 := refToRune(refL2.Id())
 		var expectedRefsL1 []rune
 		for _, ref := range nextRefL1s {
 			expectedRefsL1 = append(expectedRefsL1, refToRune(ref))


### PR DESCRIPTION
**Description**
This flattens the Block ID fields and adds a time field to
the Block References. The time field is important for sequencing.
It needs to be in the BlockRef instead of the BlockID because
it is hard to reliably fill out the timestamp field for
Parent and L1Origin block ids.

This approach also removes the ParentNumber because it can
be easily calculated if needed, but was not being used.

It then removes having to separately keep track of L1Origin and L1Base.
This is nice because those name are confusing and separately used
and it means less information to keep track of.