### PR TITLE
linter ignore node_modules in sub dirs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "setup": "yarn install && cargo install lychee",
     "lint": "yarn lint:fix && yarn lint:check",
-    "lint:fix": "markdownlint-cli2-fix \"./opnode/README.md\" \"./specs/**/*.md\" \"#node_modules\"",
-    "lint:check": "markdownlint-cli2  \"./opnode/README.md\" \"./specs/**/*.md\" \"#node_modules\"",
+    "lint:fix": "markdownlint-cli2-fix \"./opnode/README.md\" \"./specs/**/*.md\" \"#**/node_modules\"",
+    "lint:check": "markdownlint-cli2  \"./opnode/README.md\" \"./specs/**/*.md\" \"#**/node_modules\"",
     "lint:links": "lychee --exclude twitter.com --exclude-mail README.md \"./opnode/README.md\" \"./specs/**/*.md\" \"./meta/**/*.md\" \"./opnode/**/*.md\"",
     "lint:toc": "doctoc --title=\"**Table of Contents**\" ./specs ./meta"
   }


### PR DESCRIPTION
Changes the markdown linting so that it ignores files in any `node_modules` directory, not just in the root dir.