### PR TITLE
opnode: refactor RPC server / config, prototype batch RPC endpoint (work in progress)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/status-im/keycard-go v0.0.0-20211109104530-b0e0482ba91d // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,7 @@ github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZL
 github.com/status-im/keycard-go v0.0.0-20211109104530-b0e0482ba91d h1:vmirMegf1vqPJ+lDBxLQ0MAt3tz+JL57UPxu44JBOjA=
 github.com/status-im/keycard-go v0.0.0-20211109104530-b0e0482ba91d/go.mod h1:97vT0Rym0wCnK4B++hNA3nCetr0Mh1KXaVxzSt1arjg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/opnode/flags/flags.go
+++ b/opnode/flags/flags.go
@@ -65,12 +65,6 @@ var (
 		EnvVar: prefixEnvVar("BATCHSUBMITTER_KEY"),
 	}
 
-	WithdrawalContractAddr = cli.StringFlag{
-		Name:   "rpc.withdrawalcontractaddress",
-		Usage:  "Address of the Withdrawal contract. By default, this is set to the withdrawal contract predeploy",
-		EnvVar: prefixEnvVar("WITHDRAWAL_CONTRACT_ADDR"),
-	}
-
 	LogLevelFlag = cli.StringFlag{
 		Name:   "log.level",
 		Usage:  "The lowest log level that will be output",
@@ -102,7 +96,6 @@ var requiredFlags = []cli.Flag{
 var optionalFlags = []cli.Flag{
 	SequencingEnabledFlag,
 	BatchSubmitterKeyFlag,
-	WithdrawalContractAddr,
 	LogLevelFlag,
 	LogFormatFlag,
 	LogColorFlag,

--- a/opnode/l2/source.go
+++ b/opnode/l2/source.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
+
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup/derive"
@@ -147,4 +149,62 @@ func (s *Source) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.
 		return eth.L2BlockRef{}, fmt.Errorf("failed to determine block-hash of height %v, could not get header: %w", l2Hash, err)
 	}
 	return derive.BlockReferences(block, s.genesis)
+}
+
+type ReadOnlySource struct {
+	rpc     *rpc.Client       // raw RPC client. Used for methods that do not already have bindings
+	client  *ethclient.Client // go-ethereum's wrapper around the rpc client for the eth namespace
+	genesis *rollup.Genesis
+	log     log.Logger
+}
+
+func NewReadOnlySource(ll2Node *rpc.Client, genesis *rollup.Genesis, log log.Logger) (*ReadOnlySource, error) {
+	return &ReadOnlySource{
+		rpc:     ll2Node,
+		client:  ethclient.NewClient(ll2Node),
+		genesis: genesis,
+		log:     log,
+	}, nil
+}
+
+// TODO: de-duplicate Source and ReadOnlySource.
+// We should really have a L1-downloader like binding that is more configurable and has caching.
+
+// L2BlockRefByNumber returns the canonical block and parent ids.
+func (s *ReadOnlySource) L2BlockRefByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
+	block, err := s.client.BlockByNumber(ctx, l2Num)
+	if err != nil {
+		// w%: wrap the error, we still need to detect if a canonical block is not found, a.k.a. end of chain.
+		return eth.L2BlockRef{}, fmt.Errorf("failed to determine block-hash of height %v, could not get header: %w", l2Num, err)
+	}
+	return derive.BlockReferences(block, s.genesis)
+}
+
+// L2BlockRefByHash returns the block & parent ids based on the supplied hash. The returned BlockRef may not be in the canonical chain
+func (s *ReadOnlySource) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
+	block, err := s.client.BlockByHash(ctx, l2Hash)
+	if err != nil {
+		// w%: wrap the error, we still need to detect if a canonical block is not found, a.k.a. end of chain.
+		return eth.L2BlockRef{}, fmt.Errorf("failed to determine block-hash of height %v, could not get header: %w", l2Hash, err)
+	}
+	return derive.BlockReferences(block, s.genesis)
+}
+
+func (s *ReadOnlySource) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	return s.client.BlockByNumber(ctx, number)
+}
+
+func (s *ReadOnlySource) GetBlockHeader(ctx context.Context, blockTag string) (*types.Header, error) {
+	var head *types.Header
+	err := s.rpc.CallContext(ctx, &head, "eth_getBlockByNumber", blockTag, false)
+	return head, err
+}
+
+func (s *ReadOnlySource) GetProof(ctx context.Context, address common.Address, blockTag string) (*AccountResult, error) {
+	var getProofResponse *AccountResult
+	err := s.rpc.CallContext(ctx, &getProofResponse, "eth_getProof", address, []common.Hash{}, blockTag)
+	if err == nil && getProofResponse == nil {
+		err = ethereum.NotFound
+	}
+	return getProofResponse, err
 }

--- a/opnode/l2/util.go
+++ b/opnode/l2/util.go
@@ -1,28 +1,32 @@
-package node
+package l2
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup/derive"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rlp"
 
-	"github.com/ethereum-optimism/optimistic-specs/opnode/l2"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-func ComputeL2OutputRoot(l2OutputRootVersion l2.Bytes32, blockHash common.Hash, blockRoot common.Hash, storageRoot common.Hash) l2.Bytes32 {
+func ComputeL2OutputRoot(l2OutputRootVersion Bytes32, blockHash common.Hash, blockRoot common.Hash, storageRoot common.Hash) Bytes32 {
 	var buf bytes.Buffer
 	buf.Write(l2OutputRootVersion[:])
 	buf.Write(blockRoot.Bytes())
 	buf.Write(storageRoot[:])
 	buf.Write(blockHash.Bytes())
-	return l2.Bytes32(crypto.Keccak256Hash(buf.Bytes()))
+	return Bytes32(crypto.Keccak256Hash(buf.Bytes()))
 }
 
 type AccountResult struct {
@@ -75,4 +79,44 @@ func (res *AccountResult) Verify(stateRoot common.Hash) error {
 			"  proof:   %x", accountClaimedValue, accountProofValue)
 	}
 	return err
+}
+
+// BlockToBatch converts a L2 block to batch-data.
+// Empty L2 blocks (i.e. only a L1 info deposit tx) return a nil batch with nil error.
+// Invalid L2 blocks may return an error.
+func BlockToBatch(config *rollup.Config, block *types.Block) (*derive.BatchData, error) {
+	txs := block.Transactions()
+	if len(txs) == 0 {
+		return nil, errors.New("expected at least 1 transaction but found none")
+	}
+	if typ := txs[0].Type(); typ != types.DepositTxType {
+		return nil, fmt.Errorf("expected first tx to be a deposit of L1 info, but got type: %d", typ)
+	}
+	if len(txs) == 1 { // the L1 info deposit tx, but empty otherwise, no batch data to submit
+		return nil, nil
+	}
+
+	// encode non-deposit transactions
+	var opaqueTxs []hexutil.Bytes
+	for i, tx := range block.Transactions() {
+		if tx.Type() == types.DepositTxType {
+			continue
+		}
+		otx, err := tx.MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode tx %d in block: %v", i, err)
+		}
+		opaqueTxs = append(opaqueTxs, otx)
+	}
+
+	// figure out which L1 epoch this L2 block was derived from
+	l1Num, _, _, _, err := derive.L1InfoDepositTxData(txs[0].Data())
+	if err != nil {
+		return nil, fmt.Errorf("invalid L1 info deposit tx in block: %v", err)
+	}
+	return &derive.BatchData{BatchV1: derive.BatchV1{
+		Epoch:        rollup.Epoch(l1Num), // the L1 block number equals the L2 epoch.
+		Timestamp:    block.Time(),
+		Transactions: opaqueTxs,
+	}}, nil
 }

--- a/opnode/node/api.go
+++ b/opnode/node/api.go
@@ -1,8 +1,15 @@
 package node
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup/derive"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/l2"
 	"github.com/ethereum/go-ethereum"
@@ -13,23 +20,31 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+// TODO: decide on sanity limit to not keep adding more blocks when the data size is huge.
+// I.e. don't batch together the whole L2 chain
+const MaxL2BlocksPerBatchResponse = 100
+
 type l2EthClient interface {
 	GetBlockHeader(ctx context.Context, blockTag string) (*types.Header, error)
 	// GetProof returns a proof of the account, it may return a nil result without error if the address was not found.
-	GetProof(ctx context.Context, address common.Address, blockTag string) (*AccountResult, error)
+	GetProof(ctx context.Context, address common.Address, blockTag string) (*l2.AccountResult, error)
+
+	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
+	L2BlockRefByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error)
+	L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error)
 }
 
 type nodeAPI struct {
-	client                 l2EthClient
-	withdrawalContractAddr common.Address
-	log                    log.Logger
+	config *rollup.Config
+	client l2EthClient
+	log    log.Logger
 }
 
-func newNodeAPI(l2Client l2EthClient, withdrawalContractAddr common.Address, log log.Logger) *nodeAPI {
+func newNodeAPI(config *rollup.Config, l2Client l2EthClient, log log.Logger) *nodeAPI {
 	return &nodeAPI{
-		client:                 l2Client,
-		withdrawalContractAddr: withdrawalContractAddr,
-		log:                    log,
+		config: config,
+		client: l2Client,
+		log:    log,
 	}
 }
 
@@ -45,7 +60,7 @@ func (n *nodeAPI) OutputAtBlock(ctx context.Context, number rpc.BlockNumber) ([]
 		return nil, ethereum.NotFound
 	}
 
-	proof, err := n.client.GetProof(ctx, n.withdrawalContractAddr, toBlockNumArg(number))
+	proof, err := n.client.GetProof(ctx, n.config.WithdrawalContractAddress, toBlockNumArg(number))
 	if err != nil {
 		n.log.Error("failed to get contract proof", "err", err)
 		return nil, err
@@ -60,7 +75,7 @@ func (n *nodeAPI) OutputAtBlock(ctx context.Context, number rpc.BlockNumber) ([]
 	}
 
 	var l2OutputRootVersion l2.Bytes32 // it's zero for now
-	l2OutputRoot := ComputeL2OutputRoot(l2OutputRootVersion, head.Hash(), head.Root, proof.StorageHash)
+	l2OutputRoot := l2.ComputeL2OutputRoot(l2OutputRootVersion, head.Hash(), head.Root, proof.StorageHash)
 
 	return []l2.Bytes32{l2OutputRootVersion, l2OutputRoot}, nil
 }
@@ -73,4 +88,102 @@ func toBlockNumArg(number rpc.BlockNumber) string {
 		return "pending"
 	}
 	return hexutil.EncodeUint64(uint64(number.Int64()))
+}
+
+type BatchBundleRequest struct {
+	// L2History is a list of L2 blocks that are already in-flight or confirmed.
+	// The rollup-node then finds the common point, and responds with that point as PrevL2BlockHash and PrevL2BlockNum.
+	// The L2 history is read in order of the provided hashes, which may contain arbitrary gaps and skips.
+	// The first common hash will be the continuation point.
+	// A batch-submitter may search the history using gaps to find a common point even with deep reorgs.
+	L2History []common.Hash
+
+	MaxSize hexutil.Uint64
+}
+
+type BatchBundleResponse struct {
+	PrevL2BlockHash common.Hash
+	PrevL2BlockNum  hexutil.Uint64
+
+	// LastL2BlockHash is the L2 block hash of the last block in the bundle.
+	// This is the ideal continuation point for the next batch submission.
+	// It will equal PrevL2BlockHash if there are no batches to submit.
+	LastL2BlockHash common.Hash
+
+	// Bundle represents the encoded bundle of batches.
+	// Each batch represents the inputs of a L2 block, i.e. a batch of L2 transactions (excl. deposits and such).
+	// The bundle encoding supports versioning and compression.
+	// The rollup-node determines the version to use based on configuration.
+	// Bundle is empty if there is nothing to submit.
+	Bundle hexutil.Bytes
+}
+
+func (n *nodeAPI) GetBatchBundle(ctx context.Context, req *BatchBundleRequest) (*BatchBundleResponse, error) {
+	var found eth.BlockID
+	// First find the common point with L2 history so far
+	for i, h := range req.L2History {
+		l2Ref, err := n.client.L2BlockRefByHash(ctx, h)
+		if err != nil {
+			if errors.Is(err, ethereum.NotFound) { // on reorgs and such we expect that blocks may be missing
+				continue
+			}
+			return nil, fmt.Errorf("failed to check L2 history for block hash %d in request %s: %v", i, h, err)
+		}
+		// found a block that exists! Now make sure it's really a canonical block of L2
+		canonBlock, err := n.client.L2BlockRefByNumber(ctx, big.NewInt(int64(l2Ref.Self.Number)))
+		if err != nil {
+			if errors.Is(err, ethereum.NotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to check L2 history for block number %d, expecting block %s: %v", l2Ref.Self.Number, h, err)
+		}
+		if canonBlock.Self.Hash == h {
+			// found a common canonical block!
+			found = canonBlock.Self
+			break
+		}
+	}
+	if found == (eth.BlockID{}) { // none of the L2 history could be found. At least
+		return nil, ethereum.NotFound
+	}
+
+	lastL2Hash := found.Hash
+	var batches []*derive.BatchData
+	// Now continue fetching the next blocks, and build batches, until we either run out of space, or run out of blocks.
+	for i := found.Number; i < found.Number+MaxL2BlocksPerBatchResponse; i++ {
+		l2Block, err := n.client.BlockByNumber(ctx, big.NewInt(int64(i)))
+		if err != nil {
+			if errors.Is(err, ethereum.NotFound) { // block number too high
+				break
+			}
+			return nil, fmt.Errorf("failed to retrieve L2 block by number %d: %v", i, err)
+		}
+		batch, err := l2.BlockToBatch(n.config, l2Block)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert L2 block %d (%s) to batch: %v", i, l2Block.Hash(), err)
+		}
+		if batch == nil { // empty block, nothing to submit as batch
+			continue
+		}
+		batches = append(batches, batch)
+		lastL2Hash = l2Block.Hash()
+		// TODO: estimate size of all batches so far (including compressing them together, if we reached max size yet)
+	}
+
+	var buf bytes.Buffer
+	if err := derive.EncodeBatches(n.config, batches, &buf); err != nil {
+		return nil, fmt.Errorf("failed to encode selected batches as bundle: %v", err)
+	}
+
+	// sanity check the size is within desired limit as planned
+	if size := uint64(len(buf.Bytes())); size > uint64(req.MaxSize) {
+		return nil, fmt.Errorf("batch size is wrong, ended up with bundle that is too large: %d > %d", size, req.MaxSize)
+	}
+
+	return &BatchBundleResponse{
+		PrevL2BlockHash: found.Hash,
+		PrevL2BlockNum:  hexutil.Uint64(found.Number),
+		LastL2BlockHash: lastL2Hash,
+		Bundle:          hexutil.Bytes(buf.Bytes()),
+	}, nil
 }

--- a/opnode/node/config.go
+++ b/opnode/node/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type Config struct {
@@ -22,9 +21,12 @@ type Config struct {
 	// SubmitterPrivKey, temporary config var while the batch-submitter is part of the rollup node
 	SubmitterPrivKey *ecdsa.PrivateKey
 
-	RPCListenAddr          string
-	RPCListenPort          int
-	WithdrawalContractAddr common.Address
+	RPC RPCConfig
+}
+
+type RPCConfig struct {
+	ListenAddr string
+	ListenPort int
 }
 
 // Check verifies that the given configuration makes sense

--- a/opnode/node/node.go
+++ b/opnode/node/node.go
@@ -93,7 +93,12 @@ func New(ctx context.Context, cfg *Config, log log.Logger, appVersion string) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial l2 address (%s): %w", cfg.L2NodeAddr, err)
 	}
-	server, err := newRPCServer(ctx, cfg.RPCListenAddr, cfg.RPCListenPort, &l2EthClientImpl{l2Node}, cfg.WithdrawalContractAddr, log, appVersion)
+
+	client, err := l2.NewReadOnlySource(l2Node, &genesis, log)
+	if err != nil {
+		return nil, err
+	}
+	server, err := newRPCServer(ctx, &cfg.RPC, &cfg.Rollup, client, log, appVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/opnode/node/server.go
+++ b/opnode/node/server.go
@@ -8,10 +8,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/l2"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -26,11 +25,13 @@ type rpcServer struct {
 	appVersion string
 	listenAddr net.Addr
 	log        log.Logger
+	l2.Source
 }
 
-func newRPCServer(ctx context.Context, addr string, port int, l2Client l2EthClient, withdrawalContractAddress common.Address, log log.Logger, appVersion string) (*rpcServer, error) {
-	api := newNodeAPI(l2Client, withdrawalContractAddress, log.New("rpc", "node"))
-	endpoint := fmt.Sprintf("%s:%d", addr, port)
+func newRPCServer(ctx context.Context, rpcCfg *RPCConfig, rollupCfg *rollup.Config, l2Client l2EthClient, log log.Logger, appVersion string) (*rpcServer, error) {
+	api := newNodeAPI(rollupCfg, l2Client, log.New("rpc", "node"))
+	// TODO: extend RPC config with options for WS, IPC and HTTP RPC connections
+	endpoint := fmt.Sprintf("%s:%d", rpcCfg.ListenAddr, rpcCfg.ListenPort)
 	r := &rpcServer{
 		endpoint:   endpoint,
 		api:        api,
@@ -86,23 +87,4 @@ func healthzHandler(appVersion string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(appVersion))
 	}
-}
-
-type l2EthClientImpl struct {
-	l2RPCClient *rpc.Client
-}
-
-func (c *l2EthClientImpl) GetBlockHeader(ctx context.Context, blockTag string) (*types.Header, error) {
-	var head *types.Header
-	err := c.l2RPCClient.CallContext(ctx, &head, "eth_getBlockByNumber", blockTag, false)
-	return head, err
-}
-
-func (c *l2EthClientImpl) GetProof(ctx context.Context, address common.Address, blockTag string) (*AccountResult, error) {
-	var getProofResponse *AccountResult
-	err := c.l2RPCClient.CallContext(ctx, &getProofResponse, "eth_getProof", address, []common.Hash{}, blockTag)
-	if err == nil && getProofResponse == nil {
-		err = ethereum.NotFound
-	}
-	return getProofResponse, err
 }

--- a/opnode/node/server_test.go
+++ b/opnode/node/server_test.go
@@ -3,7 +3,12 @@ package node
 import (
 	"context"
 	"encoding/json"
+	"math/big"
 	"testing"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testlog"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/l2"
@@ -59,17 +64,24 @@ func TestOutputAtBlock(t *testing.T) {
 		"nonce": "0x1",
 		"storageHash": "0xc1917a80cb25ccc50d0d1921525a44fb619b4601194ca726ae32312f08a799f8"
 	}`
-	var result AccountResult
+	var result l2.AccountResult
 	err = json.Unmarshal([]byte(resultTestData), &result)
 	assert.NoError(t, err)
 
-	l2Client := &mockL2Client{
-		head:   &header,
-		result: &result,
+	rpcCfg := &RPCConfig{
+		ListenAddr: "localhost",
+		ListenPort: 0,
+	}
+	rollupCfg := &rollup.Config{
+		WithdrawalContractAddress: common.HexToAddress("0x00000000219ab540356cBB839Cbe05303d7705Fa"),
+		// ignore other rollup config info in this test
 	}
 
-	addr := common.HexToAddress("0x00000000219ab540356cBB839Cbe05303d7705Fa")
-	server, err := newRPCServer(context.Background(), "localhost", 0, l2Client, addr, log, "0.0")
+	l2Client := &mockL2Client{}
+	l2Client.mock.On("GetBlockHeader", "latest").Return(&header)
+	l2Client.mock.On("GetProof", rollupCfg.WithdrawalContractAddress, "latest").Return(&result)
+
+	server, err := newRPCServer(context.Background(), rpcCfg, rollupCfg, l2Client, log, "0.0")
 	assert.NoError(t, err)
 	assert.NoError(t, server.Start())
 	defer server.Stop()
@@ -81,17 +93,29 @@ func TestOutputAtBlock(t *testing.T) {
 	err = client.CallContext(context.Background(), &out, "optimism_outputAtBlock", "latest")
 	assert.NoError(t, err)
 	assert.Len(t, out, 2)
+	l2Client.mock.AssertExpectations(t)
 }
 
 type mockL2Client struct {
-	head   *types.Header
-	result *AccountResult
+	mock mock.Mock
+}
+
+func (c *mockL2Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	return c.mock.MethodCalled("BlockByNumber", number).Get(0).(*types.Block), nil
+}
+
+func (c *mockL2Client) L2BlockRefByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
+	return c.mock.MethodCalled("L2BlockRefByNumber", l2Num).Get(0).(eth.L2BlockRef), nil
+}
+
+func (c *mockL2Client) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
+	return c.mock.MethodCalled("L2BlockRefByHash", l2Hash).Get(0).(eth.L2BlockRef), nil
 }
 
 func (c *mockL2Client) GetBlockHeader(ctx context.Context, blockTag string) (*types.Header, error) {
-	return c.head, nil
+	return c.mock.MethodCalled("GetBlockHeader", blockTag).Get(0).(*types.Header), nil
 }
 
-func (c *mockL2Client) GetProof(ctx context.Context, address common.Address, blockTag string) (*AccountResult, error) {
-	return c.result, nil
+func (c *mockL2Client) GetProof(ctx context.Context, address common.Address, blockTag string) (*l2.AccountResult, error) {
+	return c.mock.MethodCalled("GetProof", address, blockTag).Get(0).(*l2.AccountResult), nil
 }

--- a/opnode/rollup/types.go
+++ b/opnode/rollup/types.go
@@ -44,6 +44,8 @@ type Config struct {
 	BatchInboxAddress common.Address `json:"batch_inbox_address"`
 	// Acceptable batch-sender address
 	BatchSenderAddress common.Address `json:"batch_sender_address"`
+	// L2 address that stores withdrawal messages, enshrined as part of the output root with withdrawal_storage_hash
+	WithdrawalContractAddress common.Address `json:"withdrawal_contract_address"`
 }
 
 // Check verifies that the given configuration makes sense

--- a/opnode/service.go
+++ b/opnode/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimistic-specs/opnode/flags"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/node"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/urfave/cli"
 )
@@ -39,21 +38,17 @@ func NewConfig(ctx *cli.Context) (*node.Config, error) {
 		}
 	}
 
-	withdrawalContractAddress := WithdrawalContractAddress
-	if value := ctx.GlobalString(flags.WithdrawalContractAddr.Name); value != "" {
-		withdrawalContractAddress = common.HexToAddress(value)
-	}
-
 	cfg := &node.Config{
-		L1NodeAddr:             ctx.GlobalString(flags.L1NodeAddr.Name),
-		L2EngineAddrs:          ctx.GlobalStringSlice(flags.L2EngineAddrs.Name),
-		L2NodeAddr:             ctx.GlobalString(flags.L2EthNodeAddr.Name),
-		Rollup:                 *rollupConfig,
-		Sequencer:              enableSequencing,
-		SubmitterPrivKey:       batchSubmitterKey,
-		RPCListenAddr:          ctx.GlobalString(flags.RPCListenAddr.Name),
-		RPCListenPort:          ctx.GlobalInt(flags.RPCListenPort.Name),
-		WithdrawalContractAddr: withdrawalContractAddress,
+		L1NodeAddr:       ctx.GlobalString(flags.L1NodeAddr.Name),
+		L2EngineAddrs:    ctx.GlobalStringSlice(flags.L2EngineAddrs.Name),
+		L2NodeAddr:       ctx.GlobalString(flags.L2EthNodeAddr.Name),
+		Rollup:           *rollupConfig,
+		Sequencer:        enableSequencing,
+		SubmitterPrivKey: batchSubmitterKey,
+		RPC: node.RPCConfig{
+			ListenAddr: ctx.GlobalString(flags.RPCListenAddr.Name),
+			ListenPort: ctx.GlobalInt(flags.RPCListenPort.Name),
+		},
 	}
 	if err := cfg.Check(); err != nil {
 		return nil, err

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -172,9 +172,14 @@ func TestSystemE2E(t *testing.T) {
 			SeqWindowSize:        2,
 			L1ChainID:            big.NewInt(900),
 			// TODO pick defaults
-			FeeRecipientAddress: common.Address{0xff, 0x01},
-			BatchInboxAddress:   common.Address{0xff, 0x02},
-			BatchSenderAddress:  submitterAddress,
+			FeeRecipientAddress:       common.Address{0xff, 0x01},
+			BatchInboxAddress:         common.Address{0xff, 0x02},
+			BatchSenderAddress:        submitterAddress,
+			WithdrawalContractAddress: common.Address{0xff, 0x03}, // TODO: pre-deploy withdrawal contract
+		},
+		RPC: rollupNode.RPCConfig{
+			ListenAddr: "localhost",
+			ListenPort: cfg.l2Sequencer.nodeConfig.HTTPPort,
 		},
 	}
 	node, err := rollupNode.New(context.Background(), nodeCfg, testlog.Logger(t, log.LvlError), "")
@@ -188,7 +193,7 @@ func TestSystemE2E(t *testing.T) {
 	sequenceCfg := &rollupNode.Config{
 		L1NodeAddr:    endpoint(cfg.l1.nodeConfig),
 		L2EngineAddrs: []string{endpoint(cfg.l2Sequencer.nodeConfig)},
-		L2NodeAddr:    endpoint(cfg.l2Verifier.nodeConfig),
+		L2NodeAddr:    endpoint(cfg.l2Sequencer.nodeConfig),
 		Rollup: rollup.Config{
 			Genesis: rollup.Genesis{
 				L1:     l1GenesisID,
@@ -200,12 +205,17 @@ func TestSystemE2E(t *testing.T) {
 			SeqWindowSize:        2,
 			L1ChainID:            big.NewInt(900),
 			// TODO pick defaults
-			FeeRecipientAddress: common.Address{0xff, 0x01},
-			BatchInboxAddress:   common.Address{0xff, 0x02},
-			BatchSenderAddress:  submitterAddress,
+			FeeRecipientAddress:       common.Address{0xff, 0x01},
+			BatchInboxAddress:         common.Address{0xff, 0x02},
+			BatchSenderAddress:        submitterAddress,
+			WithdrawalContractAddress: common.Address{0xff, 0x03}, // TODO: pre-deploy withdrawal contract
 		},
 		Sequencer:        true,
 		SubmitterPrivKey: bssPrivKey,
+		RPC: rollupNode.RPCConfig{
+			ListenAddr: "localhost",
+			ListenPort: cfg.l2Sequencer.nodeConfig.HTTPPort,
+		},
 	}
 	sequencer, err := rollupNode.New(context.Background(), sequenceCfg, testlog.Logger(t, log.LvlError), "")
 	require.Nil(t, err)


### PR DESCRIPTION
This PR implements the RPC server for batch-submitter.

Changes:
- Clean up output submitter test mock, use mocking lib
- Move WithdrawalContractAddress to the rollup node chain config, where the other system-critical addresses are defined. This address should never suddenly change, it's not a CLI parameter.
- Update e2e test with config changes
- Get rid of rpc l2 client bindings that were used in output submitter. Instead introduce a read-only l2 source, and move the l2 logic into the l2 package. Next goal is to unify better with the other l2 client bindings, to de-duplicate the readonly methods with the read/write bindings, and cache things.
- Extend l2 client bindings with block ref getters and block getter
- Method to convert L2 block to batch


### RPC design for batch submitter

Based on discussion with @cfromknecht :

Light-weight batch-submitter, focused on managing its own transactions. The only stateful thing it has is that it remembers the *last* (not even each individual) block hash of each of the batches it submitted.
We can host the state in some reliable/redundant/fast external database in production, but should have a default for testing that just stores this state locally (literally only a list of recent block hashes, about ~20 KB for a worst-case reorg of 20 min of L2 data that is all sequenced but never submitter/confirmed).


The batch-submitter can then ask the rollup-node for batches, and give any arbitrary list of block-hashes. The first common hash with the canonical L2 chain will be the resumption point (i.e. all L2 blocks with higher block height will be included in the batches). The rollup-node returns an encoded bundle of batches, possibly including compression etc. The result should be built to be smaller than the requested size .


TODOs:
- [ ] Fix batch rpc endpoint to respect parameter of desired max size
- [ ] More sanity limits
- [ ] Testing
- [ ] Clean up the L2 source. It should have caching like the new L1 downloader. And unify more of the RPC methods with the engine API source, and type things better (e.g. no string "blockTag")

We can remove the prototype batch-submitter from driver-loop once we integrate the external batch-submitter in the E2E test.
Similarly I think we should integrate the withdrawals process (just like we do deposits), and the output-root submitter.
