### PR TITLE
l2os: Submit l2 output root via opnode

### DIFF
--- a/l2os/config.go
+++ b/l2os/config.go
@@ -61,7 +61,7 @@ func NewConfig(ctx *cli.Context) Config {
 		/* Required Flags */
 		L1EthRpc:                  ctx.GlobalString(flags.L1EthRpcFlag.Name),
 		L2EthRpc:                  ctx.GlobalString(flags.L2EthRpcFlag.Name),
-		RollupRpc:                 ctx.GlobalString(flags.RollupRpc.Name),
+		RollupRpc:                 ctx.GlobalString(flags.RollupRpcFlag.Name),
 		L2OOAddress:               ctx.GlobalString(flags.L2OOAddressFlag.Name),
 		PollInterval:              ctx.GlobalDuration(flags.PollIntervalFlag.Name),
 		NumConfirmations:          ctx.GlobalUint64(flags.NumConfirmationsFlag.Name),

--- a/l2os/config.go
+++ b/l2os/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	// L2EthRpc is the HTTP provider URL for L1.
 	L2EthRpc string
 
+	// RollupRpc is the HTTP provider URL for the rollup node.
+	RollupRpc string
+
 	// L2OOAddress is the L2OutputOracle contract address.
 	L2OOAddress string
 
@@ -58,6 +61,7 @@ func NewConfig(ctx *cli.Context) Config {
 		/* Required Flags */
 		L1EthRpc:                  ctx.GlobalString(flags.L1EthRpcFlag.Name),
 		L2EthRpc:                  ctx.GlobalString(flags.L2EthRpcFlag.Name),
+		RollupRpc:                 ctx.GlobalString(flags.RollupRpc.Name),
 		L2OOAddress:               ctx.GlobalString(flags.L2OOAddressFlag.Name),
 		PollInterval:              ctx.GlobalDuration(flags.PollIntervalFlag.Name),
 		NumConfirmations:          ctx.GlobalUint64(flags.NumConfirmationsFlag.Name),

--- a/l2os/drivers/l2output/driver.go
+++ b/l2os/drivers/l2output/driver.go
@@ -8,16 +8,15 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimistic-specs/l2os/bindings/l2oo"
+	"github.com/ethereum-optimism/optimistic-specs/l2os/rollupclient"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/l2"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
 )
 
 var bigOne = big.NewInt(1)
@@ -27,7 +26,7 @@ type Config struct {
 	Name         string
 	L1Client     *ethclient.Client
 	L2Client     *ethclient.Client
-	RollupClient *rpc.Client
+	RollupClient *rollupclient.RollupClient
 	L2OOAddr     common.Address
 	ChainID      *big.Int
 	PrivKey      *ecdsa.PrivateKey
@@ -245,8 +244,8 @@ func (d *Driver) SendTransaction(
 }
 
 func (d *Driver) outputRootAtBlock(ctx context.Context, blockNum *big.Int) (l2.Bytes32, error) {
-	var output []l2.Bytes32
-	if err := d.cfg.RollupClient.CallContext(ctx, &output, "optimism_outputAtBlock", hexutil.EncodeBig(blockNum)); err != nil {
+	output, err := d.cfg.RollupClient.OutputAtBlock(ctx, blockNum)
+	if err != nil {
 		return l2.Bytes32{}, err
 	}
 	if len(output) != 2 {

--- a/l2os/flags/flags.go
+++ b/l2os/flags/flags.go
@@ -25,7 +25,7 @@ var (
 		Required: true,
 		EnvVar:   "L2_ETH_RPC",
 	}
-	RollupRpc = cli.StringFlag{
+	RollupRpcFlag = cli.StringFlag{
 		Name:     "rollup-rpc",
 		Usage:    "HTTP provider URL for the rollup node",
 		Required: true,
@@ -94,7 +94,7 @@ var (
 var requiredFlags = []cli.Flag{
 	L1EthRpcFlag,
 	L2EthRpcFlag,
-	RollupRpc,
+	RollupRpcFlag,
 	L2OOAddressFlag,
 	PollIntervalFlag,
 	NumConfirmationsFlag,

--- a/l2os/flags/flags.go
+++ b/l2os/flags/flags.go
@@ -25,6 +25,12 @@ var (
 		Required: true,
 		EnvVar:   "L2_ETH_RPC",
 	}
+	RollupRpc = cli.StringFlag{
+		Name:     "rollup-rpc",
+		Usage:    "HTTP provider URL for the rollup node",
+		Required: true,
+		EnvVar:   "ROLLUP_RPC",
+	}
 	L2OOAddressFlag = cli.StringFlag{
 		Name:     "l2oo-address",
 		Usage:    "Address of the L2OutputOracle contract",
@@ -88,6 +94,7 @@ var (
 var requiredFlags = []cli.Flag{
 	L1EthRpcFlag,
 	L2EthRpcFlag,
+	RollupRpc,
 	L2OOAddressFlag,
 	PollIntervalFlag,
 	NumConfirmationsFlag,

--- a/l2os/l2_output_submitter.go
+++ b/l2os/l2_output_submitter.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimistic-specs/l2os/drivers/l2output"
+	"github.com/ethereum-optimism/optimistic-specs/l2os/rollupclient"
 	"github.com/ethereum-optimism/optimistic-specs/l2os/txmgr"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -139,7 +140,7 @@ func NewL2OutputSubmitter(cfg Config, gitVersion string) (*L2OutputSubmitter, er
 		Name:         "L2Output Submitter",
 		L1Client:     l1Client,
 		L2Client:     l2Client,
-		RollupClient: rollupClient,
+		RollupClient: rollupclient.NewRollupClient(rollupClient),
 		L2OOAddr:     l2ooAddress,
 		ChainID:      chainID,
 		PrivKey:      l2OutputPrivKey,

--- a/l2os/rollupclient/rollupclient.go
+++ b/l2os/rollupclient/rollupclient.go
@@ -1,0 +1,24 @@
+package rollupclient
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/l2"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type RollupClient struct {
+	rpc *rpc.Client
+}
+
+func NewRollupClient(rpc *rpc.Client) *RollupClient {
+	return &RollupClient{rpc}
+}
+
+func (r *RollupClient) OutputAtBlock(ctx context.Context, blockNum *big.Int) ([]l2.Bytes32, error) {
+	var output []l2.Bytes32
+	err := r.rpc.CallContext(ctx, &output, "optimism_outputAtBlock", hexutil.EncodeBig(blockNum))
+	return output, err
+}


### PR DESCRIPTION
Using the opnode's `optimism_outputAtBlock` RPC, we can submit l2 output roots.