### PR TITLE
opnode: Test Utilities

### DIFF
--- a/opnode/internal/testutils/fake_chain.go
+++ b/opnode/internal/testutils/fake_chain.go
@@ -1,4 +1,4 @@
-package driver
+package testutils
 
 import (
 	"context"
@@ -14,10 +14,10 @@ import (
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
 )
 
-func fakeGenesis(l1 rune, l2 rune, l2offset int) rollup.Genesis {
+func FakeGenesis(l1 rune, l2 rune, l1GenesisNumber int) rollup.Genesis {
 	return rollup.Genesis{
-		L1: fakeID(l1, 0),
-		L2: fakeID(l2, uint64(l2offset)),
+		L1: fakeID(l1, uint64(l1GenesisNumber)),
+		L2: fakeID(l2, 0),
 	}
 }
 
@@ -55,35 +55,35 @@ func chainL1(offset uint64, ids string) (out []eth.L1BlockRef) {
 	return
 }
 
-func chainL2(l1 []eth.L1BlockRef, ids string) (out []eth.L2BlockRef) {
+func chainL2(offset int, l1 []eth.L1BlockRef, ids string) (out []eth.L2BlockRef) {
 	var prevID rune
 	for i, id := range ids {
-		out = append(out, fakeL2Block(id, prevID, l1[i].ID(), uint64(i)))
+		out = append(out, fakeL2Block(id, prevID, l1[i+int(offset)].ID(), uint64(i)))
 		prevID = id
 	}
 	return
 }
 
-func NewFakeChainSource(l1 []string, l2 []string, log log.Logger) *fakeChainSource {
+func NewFakeChainSource(l1 []string, l2 []string, l1GenesisNumber int, log log.Logger) *FakeChainSource {
 	var l1s [][]eth.L1BlockRef
 	for _, l1string := range l1 {
 		l1s = append(l1s, chainL1(0, l1string))
 	}
 	var l2s [][]eth.L2BlockRef
 	for i, l2string := range l2 {
-		l2s = append(l2s, chainL2(l1s[i], l2string))
+		l2s = append(l2s, chainL2(l1GenesisNumber, l1s[i], l2string))
 	}
-	return &fakeChainSource{
+	return &FakeChainSource{
 		l1s: l1s,
 		l2s: l2s,
 		log: log,
 	}
 }
 
-// fakeChainSource implements the ChainSource interface with the ability to control
+// FakeChainSource implements the ChainSource interface with the ability to control
 // what the head block is of the L1 and L2 chains. In addition, it enables re-orgs
 // to easily be implemented
-type fakeChainSource struct {
+type FakeChainSource struct {
 	l1reorg int                // Index of the L1 chain to be operating on
 	l2reorg int                // Index of the L2 chain to be operating on
 	l1head  int                // Head block of the L1 chain
@@ -93,7 +93,7 @@ type fakeChainSource struct {
 	log     log.Logger
 }
 
-func (m *fakeChainSource) L1Range(ctx context.Context, base eth.BlockID, max uint64) ([]eth.BlockID, error) {
+func (m *FakeChainSource) L1Range(ctx context.Context, base eth.BlockID, max uint64) ([]eth.BlockID, error) {
 	var out []eth.BlockID
 	found := false
 	for i, b := range m.l1s[m.l1reorg] {
@@ -114,7 +114,7 @@ func (m *fakeChainSource) L1Range(ctx context.Context, base eth.BlockID, max uin
 	return nil, ethereum.NotFound
 }
 
-func (m *fakeChainSource) L1BlockRefByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error) {
+func (m *FakeChainSource) L1BlockRefByNumber(ctx context.Context, l1Num uint64) (eth.L1BlockRef, error) {
 	m.log.Trace("L1BlockRefByNumber", "l1Num", l1Num, "l1Head", m.l1head, "reorg", m.l1reorg)
 	if l1Num > uint64(m.l1head) {
 		return eth.L1BlockRef{}, ethereum.NotFound
@@ -122,7 +122,7 @@ func (m *fakeChainSource) L1BlockRefByNumber(ctx context.Context, l1Num uint64) 
 	return m.l1s[m.l1reorg][l1Num], nil
 }
 
-func (m *fakeChainSource) L1BlockRefByHash(ctx context.Context, l1Hash common.Hash) (eth.L1BlockRef, error) {
+func (m *FakeChainSource) L1BlockRefByHash(ctx context.Context, l1Hash common.Hash) (eth.L1BlockRef, error) {
 	m.log.Trace("L1BlockRefByHash", "l1Hash", l1Hash, "l1Head", m.l1head, "reorg", m.l1reorg)
 	for i, bl := range m.l1s[m.l1reorg] {
 		if bl.Hash == l1Hash {
@@ -132,7 +132,7 @@ func (m *fakeChainSource) L1BlockRefByHash(ctx context.Context, l1Hash common.Ha
 	return eth.L1BlockRef{}, ethereum.NotFound
 }
 
-func (m *fakeChainSource) L1HeadBlockRef(ctx context.Context) (eth.L1BlockRef, error) {
+func (m *FakeChainSource) L1HeadBlockRef(ctx context.Context) (eth.L1BlockRef, error) {
 	m.log.Trace("L1HeadBlockRef", "l1Head", m.l1head, "reorg", m.l1reorg)
 	l := len(m.l1s[m.l1reorg])
 	if l == 0 {
@@ -141,7 +141,7 @@ func (m *fakeChainSource) L1HeadBlockRef(ctx context.Context) (eth.L1BlockRef, e
 	return m.l1s[m.l1reorg][m.l1head], nil
 }
 
-func (m *fakeChainSource) L2BlockRefByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
+func (m *FakeChainSource) L2BlockRefByNumber(ctx context.Context, l2Num *big.Int) (eth.L2BlockRef, error) {
 	m.log.Trace("L2BlockRefByNumber", "l2Num", l2Num, "l2Head", m.l2head, "reorg", m.l2reorg)
 	if len(m.l2s[m.l2reorg]) == 0 {
 		panic("bad test, no l2 chain")
@@ -156,7 +156,7 @@ func (m *fakeChainSource) L2BlockRefByNumber(ctx context.Context, l2Num *big.Int
 	return m.l2s[m.l2reorg][i], nil
 }
 
-func (m *fakeChainSource) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
+func (m *FakeChainSource) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
 	m.log.Trace("L2BlockRefByHash", "l2Hash", l2Hash, "l2Head", m.l2head, "reorg", m.l2reorg)
 	for i, bl := range m.l2s[m.l2reorg] {
 		if bl.Hash == l2Hash {
@@ -166,7 +166,7 @@ func (m *fakeChainSource) L2BlockRefByHash(ctx context.Context, l2Hash common.Ha
 	return eth.L2BlockRef{}, ethereum.NotFound
 }
 
-func (m *fakeChainSource) ForkchoiceUpdate(ctx context.Context, state *l2.ForkchoiceState, attr *l2.PayloadAttributes) (*l2.ForkchoiceUpdatedResult, error) {
+func (m *FakeChainSource) ForkchoiceUpdate(ctx context.Context, state *l2.ForkchoiceState, attr *l2.PayloadAttributes) (*l2.ForkchoiceUpdatedResult, error) {
 	m.log.Trace("ForkchoiceUpdate", "newHead", state.HeadBlockHash, "l2Head", m.l2head, "reorg", m.l2reorg)
 	m.l2reorg++
 	if m.l2reorg >= len(m.l2s) {
@@ -181,10 +181,7 @@ func (m *fakeChainSource) ForkchoiceUpdate(ctx context.Context, state *l2.Forkch
 	return nil, errors.New("unable to set new head")
 }
 
-var _ L1Chain = (*fakeChainSource)(nil)
-var _ L2Chain = (*fakeChainSource)(nil)
-
-func (m *fakeChainSource) reorgL1() {
+func (m *FakeChainSource) ReorgL1() {
 	m.log.Trace("Reorg L1", "new_reorg", m.l1reorg+1, "old_reorg", m.l1reorg)
 	m.l1reorg++
 	if m.l1reorg >= len(m.l1s) {
@@ -192,7 +189,7 @@ func (m *fakeChainSource) reorgL1() {
 	}
 }
 
-func (m *fakeChainSource) setL2Head(head int) eth.L2BlockRef {
+func (m *FakeChainSource) SetL2Head(head int) eth.L2BlockRef {
 	m.log.Trace("Set L2 head", "new_head", head, "old_head", m.l2head)
 	m.l2head = head
 	if m.l2head >= len(m.l2s[m.l2reorg]) {
@@ -201,7 +198,7 @@ func (m *fakeChainSource) setL2Head(head int) eth.L2BlockRef {
 	return m.l2s[m.l2reorg][m.l2head]
 }
 
-func (m *fakeChainSource) advanceL1() eth.L1BlockRef {
+func (m *FakeChainSource) AdvanceL1() eth.L1BlockRef {
 	m.log.Trace("Advance L1", "new_head", m.l1head+1, "old_head", m.l1head)
 	m.l1head++
 	if m.l1head >= len(m.l1s[m.l1reorg]) {
@@ -210,7 +207,7 @@ func (m *fakeChainSource) advanceL1() eth.L1BlockRef {
 	return m.l1s[m.l1reorg][m.l1head]
 }
 
-func (m *fakeChainSource) l1Head() eth.L1BlockRef {
+func (m *FakeChainSource) L1Head() eth.L1BlockRef {
 	m.log.Trace("L1 Head", "head", m.l1head)
 	return m.l1s[m.l1reorg][m.l1head]
 }

--- a/opnode/rollup/sync/start_test.go
+++ b/opnode/rollup/sync/start_test.go
@@ -5,110 +5,45 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testlog"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testutils"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
-	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
-type fakeChainSource struct {
-	L1 []eth.L1BlockRef
-	L2 map[common.Hash]eth.L2BlockRef
-}
+var _ L1Chain = (*testutils.FakeChainSource)(nil)
+var _ L2Chain = (*testutils.FakeChainSource)(nil)
 
-func (m *fakeChainSource) L1HeadBlockRef(ctx context.Context) (eth.L1BlockRef, error) {
-	return m.L1[len(m.L1)-1], nil
-}
-
-func (m *fakeChainSource) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
-	n := int(number)
-	if n >= len(m.L1) {
-		return eth.L1BlockRef{}, ethereum.NotFound
+// generateFakeL2 creates a fake L2 chain with the following conditions:
+// - The L2 chain is based off of the L1 chain
+// - The actual L1 chain is the New L1 chain
+// - Both heads are at the tip of their respective chains
+func (c *syncStartTestCase) generateFakeL2(t *testing.T) (*testutils.FakeChainSource, eth.L2BlockRef, rollup.Genesis) {
+	log := testlog.Logger(t, log.LvlTrace)
+	chain := testutils.NewFakeChainSource([]string{c.L1, c.NewL1}, []string{c.L2}, int(c.GenesisL1Num), log)
+	chain.SetL2Head(len(c.L2) - 1)
+	genesis := testutils.FakeGenesis(c.GenesisL1, c.GenesisL2, int(c.GenesisL1Num))
+	head, err := chain.L2BlockRefByNumber(context.Background(), nil)
+	require.Nil(t, err)
+	chain.ReorgL1()
+	for i := 0; i < len(c.NewL1)-1; i++ {
+		chain.AdvanceL1()
 	}
-	return m.L1[n], nil
-}
-
-func (m *fakeChainSource) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
-	ref, ok := m.L2[l2Hash]
-	if !ok {
-		return eth.L2BlockRef{}, ethereum.NotFound
-	}
-	return ref, nil
-}
-
-var _ L1Chain = (*fakeChainSource)(nil)
-var _ L2Chain = (*fakeChainSource)(nil)
-
-func fakeID(id rune, num uint64) eth.BlockID {
-	var h common.Hash
-	copy(h[:], string(id))
-	return eth.BlockID{Hash: h, Number: uint64(num)}
-}
-
-func fakeL1Block(self rune, parent rune, num uint64) eth.L1BlockRef {
-	var parentID eth.BlockID
-	if num != 0 {
-		parentID = fakeID(parent, num-1)
-	}
-	id := fakeID(self, num)
-	return eth.L1BlockRef{Hash: id.Hash, Number: id.Number, ParentHash: parentID.Hash}
-}
-
-func fakeL2Block(self rune, parent rune, l1parent eth.BlockID, num uint64) eth.L2BlockRef {
-	var parentID eth.BlockID
-	if num != 0 {
-		parentID = fakeID(parent, num-1)
-	}
-	id := fakeID(self, num)
-	return eth.L2BlockRef{Hash: id.Hash, Number: id.Number, ParentHash: parentID.Hash, L1Origin: l1parent}
-}
-
-func (c *syncStartTestCase) generateFakeL2() (*fakeChainSource, eth.L2BlockRef, rollup.Genesis) {
-	var l1 []eth.L1BlockRef
-	var newl1 []eth.L1BlockRef
-	var prevID rune
-	for i, id := range c.L1 {
-		l1 = append(l1, fakeL1Block(id, prevID, uint64(i)))
-		// fmt.Printf("%v\t%v\n", l1[i].Self, l1[i].Parent)
-		prevID = id
-	}
-	prevID = rune(0)
-	for i, id := range c.NewL1 {
-		newl1 = append(newl1, fakeL1Block(id, prevID, uint64(i)))
-		// fmt.Printf("%v\t%v\n", newl1[i].Self, newl1[i].Parent)
-		prevID = id
-	}
-
-	prevID = rune(0)
-	var head eth.L2BlockRef
-	m := make(map[common.Hash]eth.L2BlockRef)
-	for i, id := range c.L2 {
-		b := fakeL2Block(id, prevID, l1[i+int(c.GenesisL1Num)].ID(), uint64(i)+c.GenesisL2Num)
-		m[b.Hash] = b
-		// fmt.Printf("%v\t%v\t%v\n", b.Self, b.Parent, b.L1Origin)
-		prevID = id
-		head = b
-	}
-	genesis := rollup.Genesis{
-		L1: fakeID(c.GenesisL1, c.GenesisL1Num),
-		L2: fakeID(c.GenesisL2, c.GenesisL2Num),
-	}
-	return &fakeChainSource{L1: newl1, L2: m}, head, genesis
+	return chain, head, genesis
 
 }
 
 type syncStartTestCase struct {
 	Name string
 
-	L1        string // L1 Chain prior to a re-org or other change
-	L2        string // L2 Chain that follows from L1Chain
-	NewL1     string // New L1 chain
-	ReorgBase rune   // Highest L1 block in the pre and post re-org L1 chian
+	L1    string // L1 Chain prior to a re-org or other change
+	L2    string // L2 Chain that follows from L1Chain
+	NewL1 string // New L1 chain
 
 	GenesisL1    rune
 	GenesisL1Num uint64
 	GenesisL2    rune
-	GenesisL2Num uint64
 
 	SeqWindowSize uint64
 	SafeL2Head    rune
@@ -121,9 +56,9 @@ func refToRune(r eth.BlockID) rune {
 }
 
 func (c *syncStartTestCase) Run(t *testing.T) {
-	msr, l2Head, genesis := c.generateFakeL2()
+	chain, l2Head, genesis := c.generateFakeL2(t)
 
-	unsafeL2Head, safeHead, err := FindL2Heads(context.TODO(), l2Head, c.SeqWindowSize, msr, msr, &genesis)
+	unsafeL2Head, safeHead, err := FindL2Heads(context.Background(), l2Head, c.SeqWindowSize, chain, chain, &genesis)
 
 	if c.ExpectedErr != nil {
 		require.Error(t, err, "Expecting an error in this test case")

--- a/opnode/rollup/sync/start_test.go
+++ b/opnode/rollup/sync/start_test.go
@@ -20,7 +20,7 @@ var _ L2Chain = (*testutils.FakeChainSource)(nil)
 // - The actual L1 chain is the New L1 chain
 // - Both heads are at the tip of their respective chains
 func (c *syncStartTestCase) generateFakeL2(t *testing.T) (*testutils.FakeChainSource, eth.L2BlockRef, rollup.Genesis) {
-	log := testlog.Logger(t, log.LvlTrace)
+	log := testlog.Logger(t, log.LvlError)
 	chain := testutils.NewFakeChainSource([]string{c.L1, c.NewL1}, []string{c.L2}, int(c.GenesisL1Num), log)
 	chain.SetL2Head(len(c.L2) - 1)
 	genesis := testutils.FakeGenesis(c.GenesisL1, c.GenesisL2, int(c.GenesisL1Num))

--- a/opnode/test/geth.go
+++ b/opnode/test/geth.go
@@ -1,16 +1,79 @@
 package test
 
 import (
+	"context"
 	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+	"time"
 
+	rollupEth "github.com/ethereum-optimism/optimistic-specs/opnode/eth"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/catalyst"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/node"
 
 	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
 )
+
+func getGenesisInfo(client *ethclient.Client) (id rollupEth.BlockID, timestamp uint64) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	block, err := client.BlockByNumber(ctx, common.Big0)
+	if err != nil {
+		panic(err)
+	}
+	return rollupEth.BlockID{Hash: block.Hash(), Number: block.NumberU64()}, block.Time()
+}
+
+func initL1Geth(cfg *SystemConfig, wallet *hdwallet.Wallet, genesis *core.Genesis) (*node.Node, *eth.Ethereum, error) {
+	signer := deriveAccount(wallet, cfg.CliqueSignerDerivationPath)
+	pk, err := wallet.PrivateKey(signer)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to locate private key in wallet: %w", err)
+	}
+
+	ethConfig := &ethconfig.Config{
+		NetworkId: cfg.L1ChainID.Uint64(),
+		Genesis:   genesis,
+	}
+	nodeConfig := &node.Config{
+		Name:   "l1-geth",
+		WSHost: cfg.L1WsAddr,
+		WSPort: cfg.L1WsPort,
+	}
+
+	return createGethNode(false, nodeConfig, ethConfig, []*ecdsa.PrivateKey{pk})
+}
+
+func initL2Geth(name, addr string, l2ChainID *big.Int, genesis *core.Genesis) (*node.Node, *eth.Ethereum, error) {
+	ethConfig := &ethconfig.Config{
+		NetworkId: l2ChainID.Uint64(),
+		Genesis:   genesis,
+	}
+	// Parsing ws://127.0.0.1:9091 for "127.0.0.1" and "9091"
+	s := strings.Split(addr, ":")
+	_, host, ok := strings.Cut(s[1], "//")
+	if !ok {
+		return nil, nil, fmt.Errorf("could not find ws host in %s", addr)
+	}
+	port, err := strconv.ParseInt(s[2], 10, 32)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse port from address: %w", err)
+	}
+	nodeConfig := &node.Config{
+		Name:   fmt.Sprintf("l2-geth-%v", name),
+		WSHost: host,
+		WSPort: int(port),
+	}
+	return createGethNode(true, nodeConfig, ethConfig, nil)
+}
 
 // createGethNode creates an in-memory geth node based on the configuration.
 // The private keys are added to the keystore and are unlocked.
@@ -24,8 +87,8 @@ func createGethNode(l2 bool, nodeCfg *node.Config, ethCfg *ethconfig.Config, pri
 	}
 
 	keydir := n.KeyStoreDir()
-	scryptN := keystore.LightScryptN
-	scryptP := keystore.LightScryptP
+	scryptN := 2
+	scryptP := 1
 	n.AccountManager().AddBackend(keystore.NewKeyStore(keydir, scryptN, scryptP))
 	ks := n.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
 
@@ -58,24 +121,4 @@ func createGethNode(l2 bool, nodeCfg *node.Config, ethCfg *ethconfig.Config, pri
 	}
 	return n, backend, nil
 
-}
-
-func l1Geth(cfg *systemConfig) (*node.Node, *eth.Ethereum, error) {
-	wallet, err := hdwallet.NewFromMnemonic(cfg.mnemonic)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	signer := deriveAccount(wallet, cfg.cliqueSigners[0])
-	pk, _ := wallet.PrivateKey(signer)
-
-	return createGethNode(false, cfg.l1.nodeConfig, cfg.l1.ethConfig, []*ecdsa.PrivateKey{pk})
-}
-
-func l2Geth(cfg *systemConfig) (*node.Node, *eth.Ethereum, error) {
-	return createGethNode(true, cfg.l2Verifier.nodeConfig, cfg.l2Verifier.ethConfig, nil)
-}
-
-func l2SequencerGeth(cfg *systemConfig) (*node.Node, *eth.Ethereum, error) {
-	return createGethNode(true, cfg.l2Sequencer.nodeConfig, cfg.l2Sequencer.ethConfig, nil)
 }

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -394,6 +394,10 @@ func TestMissingBatchE2E(t *testing.T) {
 	_, err = l2Verif.TransactionReceipt(ctx, tx.Hash())
 	require.Equal(t, ethereum.NotFound, err, "Found transaction in verifier when it should not have been included")
 
+	// Wait a short time for the L2 reorg to occur on the sequencer.
+	// The proper thing to do is to wait until the sequencer marks this block safe.
+	<-time.After(200 * time.Millisecond)
+
 	// Assert that the reconciliation process did an L2 reorg on the sequencer to remove the invalid block
 	block, err := l2Seq.BlockByNumber(ctx, receipt.BlockNumber)
 	require.Nil(t, err, "Get block from sequencer")

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum-optimism/optimistic-specs/l2os/rollupclient"
 	"github.com/ethereum-optimism/optimistic-specs/l2os/txmgr"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/contracts/deposit"
-	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testlog"
 	rollupNode "github.com/ethereum-optimism/optimistic-specs/opnode/node"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
@@ -26,12 +25,17 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	cliqueSignerHDPath = "m/44'/60'/0'/0/0"
+	transactorHDPath   = "m/44'/60'/0'/0/1"
+	l2OutputHDPath     = "m/44'/60'/0'/0/3"
+	bssHDPath          = "m/44'/60'/0'/0/4"
 )
 
 func waitForTransaction(hash common.Hash, client *ethclient.Client, timeout time.Duration) (*types.Receipt, error) {
@@ -54,142 +58,41 @@ func waitForTransaction(hash common.Hash, client *ethclient.Client, timeout time
 	}
 }
 
-func getGenesisInfo(client *ethclient.Client) (id eth.BlockID, timestamp uint64) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	block, err := client.BlockByNumber(ctx, common.Big0)
-	if err != nil {
-		panic(err)
-	}
-	return eth.BlockID{Hash: block.Hash(), Number: block.NumberU64()}, block.Time()
-}
-
-func endpoint(cfg *node.Config) string {
-	return fmt.Sprintf("ws://%v", cfg.WSEndpoint())
-}
-
-// TestSystemE2E sets up a L1 Geth node, a rollup node, and a L2 geth node and then confirms that L1 deposits are reflected on L2.
-// All nodes are run in process (but are the full nodes, not mocked or stubbed).
-func TestSystemE2E(t *testing.T) {
+func TestL2OutputSubmitter(t *testing.T) {
 	log.Root().SetHandler(log.DiscardHandler()) // Comment this out to see geth l1/l2 logs
 
-	const l2OutputHDPath = "m/44'/60'/0'/0/3"
-	const bssHDPath = "m/44'/60'/0'/0/4"
-
-	// System Config
-	cfg := &systemConfig{
-		mnemonic: "squirrel green gallery layer logic title habit chase clog actress language enrich body plate fun pledge gap abuse mansion define either blast alien witness",
-		l1: gethConfig{
-			nodeConfig: &node.Config{
-				Name:   "l1geth",
-				WSHost: "127.0.0.1",
-				WSPort: 9090,
-			},
-			ethConfig: &ethconfig.Config{
-				NetworkId: 900,
-			},
-		},
-		l2Verifier: gethConfig{
-			nodeConfig: &node.Config{
-				Name:   "l2gethVerify",
-				WSHost: "127.0.0.1",
-				WSPort: 9091,
-			},
-			ethConfig: &ethconfig.Config{
-				NetworkId: 901,
-			},
-		},
-		l2Sequencer: gethConfig{
-			nodeConfig: &node.Config{
-				Name:   "l2gethSeq",
-				WSHost: "127.0.0.1",
-				WSPort: 9092,
-			},
-			ethConfig: &ethconfig.Config{
-				NetworkId: 901,
-			},
-		},
-		premine: map[string]int{
-			"m/44'/60'/0'/0/0": 10000000,
-			"m/44'/60'/0'/0/1": 10000000,
-			"m/44'/60'/0'/0/2": 10000000,
+	cfg := SystemConfig{
+		Mnemonic: "squirrel green gallery layer logic title habit chase clog actress language enrich body plate fun pledge gap abuse mansion define either blast alien witness",
+		Premine: map[string]int{
+			cliqueSignerHDPath: 10000000,
+			transactorHDPath:   10000000,
 			l2OutputHDPath:     10000000,
 			bssHDPath:          10000000,
 		},
-		cliqueSigners:          []string{"m/44'/60'/0'/0/0"},
-		depositContractAddress: derive.DepositContractAddr.Hex(),
-		l1InfoPredeployAddress: derive.L1InfoPredeployAddr.Hex(),
-	}
-	// Create genesis & assign it to ethconfigs
-	initializeGenesis(cfg)
-
-	// Start L1
-	l1Node, l1Backend, err := l1Geth(cfg)
-	require.Nil(t, err)
-	defer l1Node.Close()
-
-	err = l1Node.Start()
-	require.Nil(t, err)
-
-	err = l1Backend.StartMining(1)
-	require.Nil(t, err)
-
-	l1Client, err := ethclient.Dial(endpoint(cfg.l1.nodeConfig))
-	require.Nil(t, err)
-	l1GenesisID, _ := getGenesisInfo(l1Client)
-
-	// Start L2
-	l2Node, _, err := l2Geth(cfg)
-	require.Nil(t, err)
-	defer l2Node.Close()
-
-	err = l2Node.Start()
-	require.Nil(t, err)
-
-	l2Client, err := ethclient.Dial(endpoint(cfg.l2Verifier.nodeConfig))
-	require.Nil(t, err)
-	l2GenesisID, l2GenesisTime := getGenesisInfo(l2Client)
-
-	// Start L2
-	l2SequencerNode, _, err := l2SequencerGeth(cfg)
-	require.Nil(t, err)
-	defer l2SequencerNode.Close()
-
-	err = l2SequencerNode.Start()
-	require.Nil(t, err)
-
-	l2SequencerClient, err := ethclient.Dial(endpoint(cfg.l2Sequencer.nodeConfig))
-	require.Nil(t, err)
-
-	// BSS
-	bssPrivKey, err := cfg.wallet.PrivateKey(accounts.Account{
-		URL: accounts.URL{
-			Path: bssHDPath,
-		},
-	})
-	require.Nil(t, err)
-	submitterAddress := crypto.PubkeyToAddress(bssPrivKey.PublicKey)
-
-	// Account
-	ethPrivKey, err := cfg.wallet.PrivateKey(accounts.Account{
-		URL: accounts.URL{
-			Path: "m/44'/60'/0'/0/0",
-		},
-	})
-	require.Nil(t, err)
-
-	// Verifier Rollup Node
-	nodeCfg := &rollupNode.Config{
-		L1NodeAddr:    endpoint(cfg.l1.nodeConfig),
-		L2EngineAddrs: []string{endpoint(cfg.l2Verifier.nodeConfig)},
-		L2NodeAddr:    endpoint(cfg.l2Verifier.nodeConfig),
-		L1TrustRPC:    false, // would be faster to enable, but we want to catch if the RPC is buggy
-		Rollup: rollup.Config{
-			Genesis: rollup.Genesis{
-				L1:     l1GenesisID,
-				L2:     l2GenesisID,
-				L2Time: l2GenesisTime,
+		BatchSubmitterHDPath:       bssHDPath,
+		CliqueSignerDerivationPath: cliqueSignerHDPath,
+		DepositContractAddress:     common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"),
+		L1InfoPredeployAddress:     common.HexToAddress("0x4242424242424242424242424242424242424242"),
+		L1WsAddr:                   "127.0.0.1",
+		L1WsPort:                   9090,
+		L1ChainID:                  big.NewInt(900),
+		L2ChainID:                  big.NewInt(901),
+		Nodes: map[string]rollupNode.Config{
+			"sequencer": {
+				L1NodeAddr:    "ws://127.0.0.1:9090",
+				L2EngineAddrs: []string{"ws://127.0.0.1:9092"},
+				L2NodeAddr:    "ws://127.0.0.1:9092",
+				L1TrustRPC:    false,
+				Sequencer:     true,
+				// Submitter PrivKey is set in system start for rollup nodes where sequencer = true
+				RPCListenAddr: "127.0.0.1",
+				RPCListenPort: 9093,
 			},
+		},
+		Loggers: map[string]log.Logger{
+			"sequencer": testlog.Logger(t, log.LvlError),
+		},
+		RollupConfig: rollup.Config{
 			BlockTime:         1,
 			MaxSequencerDrift: 10,
 			SeqWindowSize:     2,
@@ -197,55 +100,22 @@ func TestSystemE2E(t *testing.T) {
 			// TODO pick defaults
 			FeeRecipientAddress: common.Address{0xff, 0x01},
 			BatchInboxAddress:   common.Address{0xff, 0x02},
-			BatchSenderAddress:  submitterAddress,
+			// Batch Sender address is filled out in system start
 		},
 	}
-	node, err := rollupNode.New(context.Background(), nodeCfg, testlog.Logger(t, log.LvlError), "")
-	require.Nil(t, err)
 
-	err = node.Start(context.Background())
-	require.Nil(t, err)
-	defer node.Stop()
+	sys, err := cfg.start()
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
 
-	// Sequencer Rollup Node
-	sequenceCfg := &rollupNode.Config{
-		L1NodeAddr:    endpoint(cfg.l1.nodeConfig),
-		L2EngineAddrs: []string{endpoint(cfg.l2Sequencer.nodeConfig)},
-		L2NodeAddr:    endpoint(cfg.l2Verifier.nodeConfig),
-		L1TrustRPC:    true, // test RPC cache usage
-		Rollup: rollup.Config{
-			Genesis: rollup.Genesis{
-				L1:     l1GenesisID,
-				L2:     l2GenesisID,
-				L2Time: l2GenesisTime,
-			},
-			BlockTime:         1,
-			MaxSequencerDrift: 10,
-			SeqWindowSize:     2,
-			L1ChainID:         big.NewInt(900),
-			// TODO pick defaults
-			FeeRecipientAddress: common.Address{0xff, 0x01},
-			BatchInboxAddress:   common.Address{0xff, 0x02},
-			BatchSenderAddress:  submitterAddress,
-		},
-		Sequencer:        true,
-		SubmitterPrivKey: bssPrivKey,
-		RPCListenAddr:    "127.0.0.1",
-		RPCListenPort:    9093,
-	}
-	sequencer, err := rollupNode.New(context.Background(), sequenceCfg, testlog.Logger(t, log.LvlError), "")
-	require.Nil(t, err)
+	l1Client := sys.Clients["l1"]
 
-	err = sequencer.Start(context.Background())
-	require.Nil(t, err)
-	defer sequencer.Stop()
-
-	rollupRPCClient, err := rpc.DialContext(context.Background(), fmt.Sprintf("http://%s:%d", sequenceCfg.RPCListenAddr, sequenceCfg.RPCListenPort))
+	rollupRPCClient, err := rpc.DialContext(context.Background(), fmt.Sprintf("http://%s:%d", cfg.Nodes["sequencer"].RPCListenAddr, cfg.Nodes["sequencer"].RPCListenPort))
 	require.Nil(t, err)
 	rollupClient := rollupclient.NewRollupClient(rollupRPCClient)
 
 	// Deploy StateRootOracle
-	l2OutputPrivKey, err := cfg.wallet.PrivateKey(accounts.Account{
+	l2OutputPrivKey, err := sys.wallet.PrivateKey(accounts.Account{
 		URL: accounts.URL{
 			Path: l2OutputHDPath,
 		},
@@ -258,17 +128,13 @@ func TestSystemE2E(t *testing.T) {
 	nonce, err := l1Client.NonceAt(ctx, l2OutputAddr, nil)
 	require.Nil(t, err)
 
-	opts, err := bind.NewKeyedTransactorWithChainID(
-		l2OutputPrivKey, cfg.l1.ethConfig.Genesis.Config.ChainID,
-	)
+	opts, err := bind.NewKeyedTransactorWithChainID(l2OutputPrivKey, cfg.L1ChainID)
 	require.Nil(t, err)
 	opts.Nonce = big.NewInt(int64(nonce))
 
-	submissionFrequency := big.NewInt(10) // 10 seconds
-	l2BlockTime := big.NewInt(2)          // 2 seconds
-	l2ooAddr, tx, l2OutputOracle, err := l2oo.DeployMockL2OutputOracle(
-		opts, l1Client, submissionFrequency, l2BlockTime, [32]byte{}, big.NewInt(0),
-	)
+	submissionFrequency := big.NewInt(2) // 2 seconds
+	l2BlockTime := big.NewInt(1)         // 1 seconds
+	l2ooAddr, tx, l2OutputOracle, err := l2oo.DeployMockL2OutputOracle(opts, l1Client, submissionFrequency, l2BlockTime, [32]byte{}, big.NewInt(0))
 	require.Nil(t, err)
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
@@ -281,16 +147,16 @@ func TestSystemE2E(t *testing.T) {
 
 	// L2Output Submitter
 	l2OutputSubmitter, err := l2os.NewL2OutputSubmitter(l2os.Config{
-		L1EthRpc:                  endpoint(cfg.l1.nodeConfig),
-		L2EthRpc:                  endpoint(cfg.l2Verifier.nodeConfig),
-		RollupRpc:                 fmt.Sprintf("http://%s:%d", sequenceCfg.RPCListenAddr, sequenceCfg.RPCListenPort),
+		L1EthRpc:                  "ws://127.0.0.1:9090",
+		L2EthRpc:                  cfg.Nodes["sequencer"].L2NodeAddr,
+		RollupRpc:                 fmt.Sprintf("http://%s:%d", cfg.Nodes["sequencer"].RPCListenAddr, cfg.Nodes["sequencer"].RPCListenPort),
 		L2OOAddress:               l2ooAddr.String(),
-		PollInterval:              5 * time.Second,
+		PollInterval:              2 * time.Second,
 		NumConfirmations:          1,
-		ResubmissionTimeout:       5 * time.Second,
+		ResubmissionTimeout:       3 * time.Second,
 		SafeAbortNonceTooLowCount: 3,
 		LogLevel:                  "error",
-		Mnemonic:                  cfg.mnemonic,
+		Mnemonic:                  cfg.Mnemonic,
 		L2OutputHDPath:            l2OutputHDPath,
 	}, "")
 	require.Nil(t, err)
@@ -298,50 +164,6 @@ func TestSystemE2E(t *testing.T) {
 	err = l2OutputSubmitter.Start()
 	require.Nil(t, err)
 	defer l2OutputSubmitter.Stop()
-
-	// Send Transaction & wait for success
-	contractAddr := common.HexToAddress(cfg.depositContractAddress)
-	fromAddr := common.HexToAddress("0x30ec912c5b1d14aa6d1cb9aa7a6682415c4f7eb0")
-
-	// Contract
-	depositContract, err := deposit.NewDeposit(contractAddr, l1Client)
-	require.Nil(t, err)
-
-	// Signer
-	ks := l1Node.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
-	opts, err = bind.NewKeyStoreTransactorWithChainID(ks, ks.Accounts()[0], big.NewInt(int64(cfg.l1.ethConfig.NetworkId)))
-	require.Nil(t, err)
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	startBalance, err := l2Client.BalanceAt(ctx, fromAddr, nil)
-	require.Nil(t, err, "Could not get start balance")
-
-	// Finally send TX
-	mintAmount := big.NewInt(1_000_000_000_000)
-	opts.Value = mintAmount
-	l1DepTx, err := depositContract.DepositTransaction(opts, fromAddr, common.Big0, big.NewInt(1_000_000), false, nil)
-	require.Nil(t, err, "with deposit tx")
-
-	receipt, err := waitForTransaction(l1DepTx.Hash(), l1Client, 6*time.Second)
-	require.Nil(t, err, "Waiting for tx")
-
-	reconstructedDep, err := derive.UnmarshalLogEvent(receipt.Logs[0])
-	require.NoError(t, err)
-	l2DepTx := types.NewTx(reconstructedDep)
-	receipt, err = waitForTransaction(l2DepTx.Hash(), l2Client, 6*time.Second)
-	require.NoError(t, err)
-	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
-
-	// Confirm balance
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	endBalance, err := l2Client.BalanceAt(ctx, fromAddr, nil)
-	require.Nil(t, err)
-
-	diff := new(big.Int)
-	diff = diff.Sub(endBalance, startBalance)
-	require.Equal(t, diff, mintAmount, "Did not get expected balance change")
 
 	// Wait for batch submitter to update L2 output oracle.
 	timeoutCh := time.After(15 * time.Second)
@@ -384,26 +206,147 @@ func TestSystemE2E(t *testing.T) {
 		}
 	}
 
+}
+
+// TestSystemE2E sets up a L1 Geth node, a rollup node, and a L2 geth node and then confirms that L1 deposits are reflected on L2.
+// All nodes are run in process (but are the full nodes, not mocked or stubbed).
+func TestSystemE2E(t *testing.T) {
+	log.Root().SetHandler(log.DiscardHandler()) // Comment this out to see geth l1/l2 logs
+
+	cfg := SystemConfig{
+		Mnemonic: "squirrel green gallery layer logic title habit chase clog actress language enrich body plate fun pledge gap abuse mansion define either blast alien witness",
+		Premine: map[string]int{
+			cliqueSignerHDPath: 10000000,
+			transactorHDPath:   10000000,
+			l2OutputHDPath:     10000000,
+			bssHDPath:          10000000,
+		},
+		BatchSubmitterHDPath:       bssHDPath,
+		CliqueSignerDerivationPath: cliqueSignerHDPath,
+		DepositContractAddress:     common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"),
+		L1InfoPredeployAddress:     common.HexToAddress("0x4242424242424242424242424242424242424242"),
+		L1WsAddr:                   "127.0.0.1",
+		L1WsPort:                   9090,
+		L1ChainID:                  big.NewInt(900),
+		L2ChainID:                  big.NewInt(901),
+		Nodes: map[string]rollupNode.Config{
+			"verifier": {
+				L1NodeAddr:    "ws://127.0.0.1:9090",
+				L2EngineAddrs: []string{"ws://127.0.0.1:9091"},
+				L2NodeAddr:    "ws://127.0.0.1:9091",
+				L1TrustRPC:    false,
+			},
+			"sequencer": {
+				L1NodeAddr:    "ws://127.0.0.1:9090",
+				L2EngineAddrs: []string{"ws://127.0.0.1:9092"},
+				L2NodeAddr:    "ws://127.0.0.1:9092",
+				L1TrustRPC:    false,
+				Sequencer:     true,
+				// Submitter PrivKey is set in system start for rollup nodes where sequencer = true
+				RPCListenAddr: "127.0.0.1",
+				RPCListenPort: 9093,
+			},
+		},
+		Loggers: map[string]log.Logger{
+			"verifier":  testlog.Logger(t, log.LvlError),
+			"sequencer": testlog.Logger(t, log.LvlError),
+		},
+		RollupConfig: rollup.Config{
+			BlockTime:         1,
+			MaxSequencerDrift: 10,
+			SeqWindowSize:     2,
+			L1ChainID:         big.NewInt(900),
+			// TODO pick defaults
+			FeeRecipientAddress: common.Address{0xff, 0x01},
+			BatchInboxAddress:   common.Address{0xff, 0x02},
+			// Batch Sender address is filled out in system start
+		},
+	}
+
+	sys, err := cfg.start()
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l1Client := sys.Clients["l1"]
+	l2Seq := sys.Clients["sequencer"]
+	l2Verif := sys.Clients["verifier"]
+
+	// Transactor Account
+	ethPrivKey, err := sys.wallet.PrivateKey(accounts.Account{
+		URL: accounts.URL{
+			Path: "m/44'/60'/0'/0/0",
+		},
+	})
+	require.Nil(t, err)
+
+	// Send Transaction & wait for success
+	fromAddr := common.HexToAddress("0x30ec912c5b1d14aa6d1cb9aa7a6682415c4f7eb0")
+
+	// Find deposit contract
+	depositContract, err := deposit.NewDeposit(cfg.DepositContractAddress, l1Client)
+	require.Nil(t, err)
+	l1Node := sys.nodes["l1"]
+
+	// Create signer
+	ks := l1Node.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
+	opts, err := bind.NewKeyStoreTransactorWithChainID(ks, ks.Accounts()[0], cfg.L1ChainID)
+	require.Nil(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	startBalance, err := l2Verif.BalanceAt(ctx, fromAddr, nil)
+	require.Nil(t, err)
+
+	// Finally send TX
+	mintAmount := big.NewInt(1_000_000_000_000)
+	opts.Value = mintAmount
+	tx, err := depositContract.DepositTransaction(opts, fromAddr, common.Big0, big.NewInt(1_000_000), false, nil)
+	require.Nil(t, err, "with deposit tx")
+
+	receipt, err := waitForTransaction(tx.Hash(), l1Client, 6*time.Second)
+	require.Nil(t, err, "Waiting for deposit tx on L1")
+
+	reconstructedDep, err := derive.UnmarshalLogEvent(receipt.Logs[0])
+	require.NoError(t, err, "Could not reconstruct L2 Deposit")
+	tx = types.NewTx(reconstructedDep)
+	receipt, err = waitForTransaction(tx.Hash(), l2Verif, 6*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
+
+	// Confirm balance
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	endBalance, err := l2Verif.BalanceAt(ctx, fromAddr, nil)
+	require.Nil(t, err)
+
+	diff := new(big.Int)
+	diff = diff.Sub(endBalance, startBalance)
+	require.Equal(t, diff, mintAmount, "Did not get expected balance change")
+
 	// Submit TX to L2 sequencer node
 	toAddr := common.Address{0xff, 0xff}
-	tx = types.MustSignNewTx(ethPrivKey, types.LatestSignerForChainID(new(big.Int).SetUint64(cfg.l2Verifier.ethConfig.NetworkId)), &types.DynamicFeeTx{
-		ChainID:   big.NewInt(int64(cfg.l2Verifier.ethConfig.NetworkId)),
-		Nonce:     1, // guess
+	tx = types.MustSignNewTx(ethPrivKey, types.LatestSignerForChainID(cfg.L2ChainID), &types.DynamicFeeTx{
+		ChainID:   cfg.L2ChainID,
+		Nonce:     1, // Already have deposit
 		To:        &toAddr,
 		Value:     big.NewInt(1_000_000_000),
 		GasTipCap: big.NewInt(10),
 		GasFeeCap: big.NewInt(200),
 		Gas:       21000,
 	})
-	err = l2SequencerClient.SendTransaction(context.Background(), tx)
+	err = l2Seq.SendTransaction(context.Background(), tx)
 	require.Nil(t, err, "Sending L2 tx to sequencer")
 
-	receipt, err = waitForTransaction(tx.Hash(), l2Client, 6*time.Second)
+	_, err = waitForTransaction(tx.Hash(), l2Seq, 6*time.Second)
+	require.Nil(t, err, "Waiting for L2 tx on sequencer")
+
+	receipt, err = waitForTransaction(tx.Hash(), l2Verif, 6*time.Second)
 	require.Nil(t, err, "Waiting for L2 tx on verifier")
 
-	verifBlock, err := l2Client.BlockByNumber(context.Background(), receipt.BlockNumber)
+	// Verify blocks match after batch submission on verifiers and sequencers
+	verifBlock, err := l2Verif.BlockByNumber(context.Background(), receipt.BlockNumber)
 	require.Nil(t, err)
-	seqBlock, err := l2SequencerClient.BlockByNumber(context.Background(), receipt.BlockNumber)
+	seqBlock, err := l2Seq.BlockByNumber(context.Background(), receipt.BlockNumber)
 	require.Nil(t, err)
 	require.Equal(t, verifBlock.Hash(), seqBlock.Hash(), "Verifier and sequencer blocks not the same after including a batch tx")
 

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -49,8 +49,8 @@ func defaultSystemConfig(t *testing.T) SystemConfig {
 		},
 		BatchSubmitterHDPath:       bssHDPath,
 		CliqueSignerDerivationPath: cliqueSignerHDPath,
-		DepositContractAddress:     common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"),
-		L1InfoPredeployAddress:     common.HexToAddress("0x4242424242424242424242424242424242424242"),
+		DepositContractAddress:     derive.DepositContractAddr,
+		L1InfoPredeployAddress:     derive.L1InfoPredeployAddr,
 		L1WsAddr:                   "127.0.0.1",
 		L1WsPort:                   9090,
 		L1ChainID:                  big.NewInt(900),
@@ -398,5 +398,4 @@ func TestMissingBatchE2E(t *testing.T) {
 	block, err := l2Seq.BlockByNumber(ctx, receipt.BlockNumber)
 	require.Nil(t, err, "Get block from sequencer")
 	require.NotEqual(t, block.Hash(), receipt.BlockHash, "L2 Sequencer did not reorg out transaction on it's safe chain")
-
 }


### PR DESCRIPTION
**Description**
This cleans up test utilities three ways
- Put `FakeChainSource` into it's own package (was split across several usages)
- Pulls out common functions like `waitForTx` in the e2e test
- Cleans up the E2E test initialization to make it easy to run tests


New E2E tests:
* L2 Output Submitter Test
* Test deposits + L2 Transactions
* Test missing batches