### PR TITLE
Update predeploy addresses

### DIFF
--- a/opnode/predeploys.go
+++ b/opnode/predeploys.go
@@ -2,4 +2,4 @@ package opnode
 
 import "github.com/ethereum/go-ethereum/common"
 
-var WithdrawalContractAddress = common.HexToAddress("0x4200000000000000000000000000000000000015")
+var WithdrawalContractAddress = common.HexToAddress("0x4200000000000000000000000000000000000016")

--- a/packages/contracts/contracts/L2/Withdrawer.sol
+++ b/packages/contracts/contracts/L2/Withdrawer.sol
@@ -12,7 +12,7 @@ import { Burner } from "./Burner.sol";
 /**
  * @title Withdrawer
  * @notice The Withdrawer contract facilitates sending both ETH value and data from L2 to L1.
- * It is predeployed in the L2 state at address 0x4200000000000000000000000000000000000015.
+ * It is predeployed in the L2 state at address 0x4200000000000000000000000000000000000016.
  */
 contract Withdrawer {
     /**********

--- a/packages/contracts/contracts/test/OptimismPortal.t.sol
+++ b/packages/contracts/contracts/test/OptimismPortal.t.sol
@@ -42,7 +42,7 @@ contract OptimismPortal_finalizeWithdrawalTransaction_Test is DSTest {
     OptimismPortal op;
 
     // Target constructor arguments
-    address withdrawalsPredeploy = 0x4200000000000000000000000000000000000015;
+    address withdrawalsPredeploy = 0x4200000000000000000000000000000000000016;
 
     // Cache of timestamps
     uint256 startingBlockTimestamp;

--- a/packages/contracts/test/withdrawer.spec.ts
+++ b/packages/contracts/test/withdrawer.spec.ts
@@ -16,7 +16,7 @@ import * as rlp from 'rlp'
 const l2GethProvider = new providers.JsonRpcProvider('http://localhost:9545')
 const l1GethProvider = new providers.JsonRpcProvider('http://localhost:8545')
 
-const withdrawerAddress = '0x4200000000000000000000000000000000000015'
+const withdrawerAddress = '0x4200000000000000000000000000000000000016'
 
 const NON_ZERO_ADDRESS = '0x' + '11'.repeat(20)
 const NON_ZERO_GASLIMIT = BigNumber.from(50_000)

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -142,7 +142,7 @@ This transaction MUST have the following values:
 
 1. `from` is `0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001` (the address of the
 [L1 Attributes depositor account][depositor-account])
-2. `to` is `0x4200000000000000000000000000000000000014` (the address of the [L1 attributes predeployed
+2. `to` is `0x4200000000000000000000000000000000000015` (the address of the [L1 attributes predeployed
    contract][predeploy]).
 3. `mint` is `0`
 4. `value` is `0`
@@ -172,7 +172,7 @@ opcodes during execution of the L1 attributes deposited transaction.
 
 [predeploy]: #l1-attributes-predeployed-contract
 
-A predeployed contract on L2 at address `0x4200000000000000000000000000000000000014`, which holds
+A predeployed contract on L2 at address `0x4200000000000000000000000000000000000015`, which holds
 certain block variables from the corresponding L1 block in storage, so that they may be accessed
 during the execution of the subsequent deposited transactions.
 

--- a/specs/withdrawals.md
+++ b/specs/withdrawals.md
@@ -72,7 +72,7 @@ An L2 account sends a withdrawal message (and possibly also ETH) to the `Withdra
 ## The L2 Withdrawer Contract
 
 A withdrawal is initiated by calling the Withdrawer contract's `initiateWithdrawal` function.
-The Withdrawer is a simple predeploy contract at `0x4200000000000000000000000000000000000015` which stores messages
+The Withdrawer is a simple predeploy contract at `0x4200000000000000000000000000000000000016` which stores messages
 to be withdrawn.
 
 ```js


### PR DESCRIPTION
The Bedrock predeploy addresses are incremented by 1 in order to avoid
conflicts with the system addresses.

