### PR TITLE
ops: fix formatting, add docker buildkit support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ devnet-up:
 .PHONY: devnet-up
 
 devnet-down:
-	@(cd ./ops && docker-compose down)
+	@(cd ./ops && docker-compose down -v)
 .PHONY: devnet-stop

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ devnet-up:
 		DEPOSIT_FEED_BYTECODE=$(shell cat ./packages/contracts/artifacts/contracts/L1/DepositFeed.sol/DepositFeed.json | jq .deployedBytecode) \
 			L1_BLOCK_INFO_BYTECODE=$(shell cat ./packages/contracts/artifacts/contracts/L2/L1Block.sol/L1Block.json | jq .deployedBytecode) \
 			WITHDRAWER_BYTECODE=$(shell cat ./packages/contracts/artifacts/contracts/L2/Withdrawer.sol/Withdrawer.json | jq .deployedBytecode) \
-			GENESIS_TIMESTAMP=$(shell date +%s) \
-            BUILDKIT_PROGRESS=plain docker-compose up --build)
+            GENESIS_TIMESTAMP=$(shell date +%s) \
+            BUILDKIT_PROGRESS=plain DOCKER_BUILDKIT=1 docker-compose up --build)
 .PHONY: devnet-up
 
 devnet-down:


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Ensures that buildkit is used when building the docker setup so that it is faster, fixes a typo where a tab is used and also prune volumes on devnet down