### PR TITLE
opnode: use correct l1 info predeploy addr

### DIFF
--- a/opnode/rollup/derive/payload_attributes.go
+++ b/opnode/rollup/derive/payload_attributes.go
@@ -22,7 +22,7 @@ var (
 	DepositContractAddr = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
 	L1InfoFuncSignature = "setL1BlockValues(uint256 _number, uint256 _timestamp, uint256 _basefee, bytes32 _hash)"
 	L1InfoFuncBytes4    = crypto.Keccak256([]byte(L1InfoFuncSignature))[:4]
-	L1InfoPredeployAddr = common.HexToAddress("0x4242424242424242424242424242424242424242")
+	L1InfoPredeployAddr = common.HexToAddress("0x4200000000000000000000000000000000000015")
 )
 
 // UnmarshalLogEvent decodes an EVM log entry emitted by the deposit contract into typed deposit data.


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the predeploy address to match the specs
https://github.com/ethereum-optimism/optimistic-specs/blob/main/specs/deposits.md#l1-attributes-predeployed-contract
