### PR TITLE
opnode: use correct l1 info predeploy addr

### DIFF
--- a/opnode/rollup/derive/payload_attributes.go
+++ b/opnode/rollup/derive/payload_attributes.go
@@ -22,7 +22,7 @@ var (
 	DepositContractAddr = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
 	L1InfoFuncSignature = "setL1BlockValues(uint256 _number, uint256 _timestamp, uint256 _basefee, bytes32 _hash)"
 	L1InfoFuncBytes4    = crypto.Keccak256([]byte(L1InfoFuncSignature))[:4]
-	L1InfoPredeployAddr = common.HexToAddress("0x4242424242424242424242424242424242424242")
+	L1InfoPredeployAddr = common.HexToAddress("0x4200000000000000000000000000000000000015")
 )
 
 // UnmarshalLogEvent decodes an EVM log entry emitted by the deposit contract into typed deposit data.

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimistic-specs/opnode/internal/testlog"
 	rollupNode "github.com/ethereum-optimism/optimistic-specs/opnode/node"
 	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup/derive"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -97,8 +98,8 @@ func TestSystemE2E(t *testing.T) {
 			bssHDPath:          10000000,
 		},
 		cliqueSigners:           []string{"m/44'/60'/0'/0/0"},
-		depositContractAddress:  "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
-		l1InforPredeployAddress: "0x4242424242424242424242424242424242424242",
+		depositContractAddress:  derive.DepositContractAddr.Hex(),
+		l1InforPredeployAddress: derive.L1InfoPredeployAddr.Hex(),
 	}
 	// Create genesis & assign it to ethconfigs
 	initializeGenesis(cfg)


### PR DESCRIPTION
**Description**

Updates the predeploy address to match the specs
https://github.com/ethereum-optimism/optimistic-specs/blob/main/specs/deposits.md#l1-attributes-predeployed-contract

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

