### PR TITLE
opnode: Don't allow arbitrary mints

### DIFF
--- a/opnode/rollup/derive/payload_attributes.go
+++ b/opnode/rollup/derive/payload_attributes.go
@@ -64,14 +64,15 @@ func UnmarshalLogEvent(blockNum uint64, txIndex uint64, ev *types.Log) (*types.D
 
 	// unindexed data
 	offset := uint64(0)
-	dep.Value = new(big.Int).SetBytes(ev.Data[offset : offset+32])
-	offset += 32
 
 	dep.Mint = new(big.Int).SetBytes(ev.Data[offset : offset+32])
 	// 0 mint is represented as nil to skip minting code
 	if dep.Mint.Cmp(new(big.Int)) == 0 {
 		dep.Mint = nil
 	}
+	offset += 32
+
+	dep.Value = new(big.Int).SetBytes(ev.Data[offset : offset+32])
 	offset += 32
 
 	gas := new(big.Int).SetBytes(ev.Data[offset : offset+32])

--- a/opnode/rollup/derive/payload_attributes_test.go
+++ b/opnode/rollup/derive/payload_attributes_test.go
@@ -72,12 +72,12 @@ func GenerateDepositLog(deposit *types.DepositTx) *types.Log {
 
 	data := make([]byte, 6*32)
 	offset := 0
-	deposit.Value.FillBytes(data[offset : offset+32])
-	offset += 32
-
 	if deposit.Mint != nil {
 		deposit.Mint.FillBytes(data[offset : offset+32])
 	}
+	offset += 32
+
+	deposit.Value.FillBytes(data[offset : offset+32])
 	offset += 32
 
 	binary.BigEndian.PutUint64(data[offset+24:offset+32], deposit.Gas)

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -312,7 +312,8 @@ func TestSystemE2E(t *testing.T) {
 
 	// Finally send TX
 	mintAmount := big.NewInt(1_000_000_000_000)
-	_, err = depositContract.DepositTransaction(opts, fromAddr, mintAmount, big.NewInt(1_000_000), false, nil)
+	opts.Value = mintAmount
+	_, err = depositContract.DepositTransaction(opts, fromAddr, common.Big0, big.NewInt(1_000_000), false, nil)
 	require.Nil(t, err, "with deposit tx")
 
 	// Wait for tx to be mined on L1 (or timeout)


### PR DESCRIPTION
The ordering of `mint, value` was switched to be `value, mint`
when parsing emitted logs. This allows users to control their
mint rather than using `msg.value` which is being fed directly
into the event.

Thanks to Mofi (Inphi) for finding this.


