### PR TITLE
opnode: don't expose types.Block to driver package, prefer l2.ExecutionPayload

### DIFF
--- a/opnode/rollup/derive/invert.go
+++ b/opnode/rollup/derive/invert.go
@@ -5,10 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimistic-specs/opnode/eth"
-	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // L1InfoDepositTxData is the inverse of L1InfoDeposit, to see where the L2 chain is derived from
@@ -26,41 +23,4 @@ func L1InfoDepositTxData(data []byte) (nr uint64, time uint64, baseFee *big.Int,
 	offset += 32
 	blockHash.SetBytes(data[offset : offset+32])
 	return
-}
-
-type Block interface {
-	Hash() common.Hash
-	NumberU64() uint64
-	ParentHash() common.Hash
-	Transactions() types.Transactions
-	Time() uint64
-}
-
-// BlockReferences takes a L2 block and determines which L1 block it was derived from, its L2 parent id, and its own id.
-func BlockReferences(l2Block Block, genesis *rollup.Genesis) (eth.L2BlockRef, error) {
-	id := eth.L2BlockRef{
-		Hash:       l2Block.Hash(),
-		Number:     l2Block.NumberU64(),
-		ParentHash: l2Block.ParentHash(),
-		Time:       l2Block.Time(),
-	}
-
-	if id.Number <= genesis.L2.Number {
-		if id.Hash != genesis.L2.Hash {
-			return eth.L2BlockRef{}, fmt.Errorf("unexpected L2 genesis block: %s:%d, expected %s", id.Hash, id.Number, genesis.L2)
-		}
-		id.L1Origin = genesis.L1
-		return id, nil
-	}
-
-	txs := l2Block.Transactions()
-	if len(txs) == 0 || txs[0].Type() != types.DepositTxType {
-		return eth.L2BlockRef{}, fmt.Errorf("l2 block is missing L1 info deposit tx, block hash: %s", l2Block.Hash())
-	}
-	l1Number, _, _, l1Hash, err := L1InfoDepositTxData(txs[0].Data())
-	if err != nil {
-		return eth.L2BlockRef{}, fmt.Errorf("failed to parse L1 info deposit tx from L2 block: %v", err)
-	}
-	id.L1Origin = eth.BlockID{Hash: l1Hash, Number: l1Number}
-	return id, nil
 }

--- a/opnode/rollup/driver/driver.go
+++ b/opnode/rollup/driver/driver.go
@@ -32,8 +32,8 @@ type Engine interface {
 	GetPayload(ctx context.Context, payloadId l2.PayloadID) (*l2.ExecutionPayload, error)
 	ForkchoiceUpdate(ctx context.Context, state *l2.ForkchoiceState, attr *l2.PayloadAttributes) (*l2.ForkchoiceUpdatedResult, error)
 	NewPayload(ctx context.Context, payload *l2.ExecutionPayload) error
-	BlockByHash(context.Context, common.Hash) (*types.Block, error)
-	BlockByNumber(context.Context, *big.Int) (*types.Block, error)
+	PayloadByHash(context.Context, common.Hash) (*l2.ExecutionPayload, error)
+	PayloadByNumber(context.Context, *big.Int) (*l2.ExecutionPayload, error)
 }
 
 type L1Chain interface {

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -89,7 +89,7 @@ func (d *outputImpl) createNewBlock(ctx context.Context, l2Head eth.L2BlockRef, 
 			Transactions: payload.Transactions[depositStart:],
 		},
 	}
-	ref, err := l2.PayloadToBlockRef(payload)
+	ref, err := l2.PayloadToBlockRef(payload, &d.Config.Genesis)
 	return ref, batch, err
 }
 
@@ -191,7 +191,7 @@ func (d *outputImpl) insertEpoch(ctx context.Context, l2Head eth.L2BlockRef, l2S
 			return lastHead, lastSafeHead, didReorg, fmt.Errorf("failed to extend L2 chain at block %d/%d of epoch %d: %w", i, len(batches), epoch, err)
 		}
 
-		newLast, err := l2.PayloadToBlockRef(payload)
+		newLast, err := l2.PayloadToBlockRef(payload, &d.Config.Genesis)
 		if err != nil {
 			return lastHead, lastSafeHead, didReorg, fmt.Errorf("failed to derive block references: %w", err)
 		}

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -85,10 +86,10 @@ func (d *outputImpl) createNewBlock(ctx context.Context, l2Head eth.L2BlockRef, 
 		BatchV1: derive.BatchV1{
 			Epoch:        rollup.Epoch(l1Info.NumberU64()),
 			Timestamp:    uint64(payload.Timestamp),
-			Transactions: payload.TransactionsField[depositStart:],
+			Transactions: payload.Transactions[depositStart:],
 		},
 	}
-	ref, err := derive.BlockReferences(payload, &d.Config.Genesis)
+	ref, err := l2.PayloadToBlockRef(payload)
 	return ref, batch, err
 }
 
@@ -110,7 +111,7 @@ func (d *outputImpl) insertEpoch(ctx context.Context, l2Head eth.L2BlockRef, l2S
 	epoch := rollup.Epoch(l1Input[0].Number)
 	fetchCtx, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
-	l2Info, err := d.l2.BlockByHash(fetchCtx, l2SafeHead.Hash)
+	l2Info, err := d.l2.PayloadByHash(fetchCtx, l2SafeHead.Hash)
 	if err != nil {
 		return l2Head, l2SafeHead, false, fmt.Errorf("failed to fetch L2 block info of %s: %w", l2SafeHead, err)
 	}
@@ -139,7 +140,7 @@ func (d *outputImpl) insertEpoch(ctx context.Context, l2Head eth.L2BlockRef, l2S
 		return l2Head, l2SafeHead, false, fmt.Errorf("failed to fetch create batches from transactions: %w", err)
 	}
 	// Make batches contiguous
-	minL2Time := l2Info.Time() + d.Config.BlockTime
+	minL2Time := uint64(l2Info.Timestamp) + d.Config.BlockTime
 	maxL2Time := l1Info.Time() + d.Config.MaxSequencerDrift
 	if minL2Time+d.Config.BlockTime > maxL2Time {
 		maxL2Time = minL2Time + d.Config.BlockTime
@@ -156,7 +157,7 @@ func (d *outputImpl) insertEpoch(ctx context.Context, l2Head eth.L2BlockRef, l2S
 	lastHead := l2Head
 	lastSafeHead := l2SafeHead
 	didReorg := false
-	var payload derive.Block
+	var payload *l2.ExecutionPayload
 	var reorg bool
 	for i, batch := range batches {
 		var txns []l2.Data
@@ -190,7 +191,7 @@ func (d *outputImpl) insertEpoch(ctx context.Context, l2Head eth.L2BlockRef, l2S
 			return lastHead, lastSafeHead, didReorg, fmt.Errorf("failed to extend L2 chain at block %d/%d of epoch %d: %w", i, len(batches), epoch, err)
 		}
 
-		newLast, err := derive.BlockReferences(payload, &d.Config.Genesis)
+		newLast, err := l2.PayloadToBlockRef(payload)
 		if err != nil {
 			return lastHead, lastSafeHead, didReorg, fmt.Errorf("failed to derive block references: %w", err)
 		}
@@ -212,29 +213,22 @@ func (d *outputImpl) insertEpoch(ctx context.Context, l2Head eth.L2BlockRef, l2S
 
 // attributesMatchBlock checks if the L2 attributes pre-inputs match the output
 // nil if it is a match. If err is not nil, the error contains the reason for the mismatch
-func attributesMatchBlock(attrs *l2.PayloadAttributes, parentHash common.Hash, block *types.Block) error {
-	if parentHash != block.ParentHash() {
-		return fmt.Errorf("parent hash field does not match. expected: %v. got: %v", parentHash, block.ParentHash())
+func attributesMatchBlock(attrs *l2.PayloadAttributes, parentHash common.Hash, block *l2.ExecutionPayload) error {
+	if parentHash != block.ParentHash {
+		return fmt.Errorf("parent hash field does not match. expected: %v. got: %v", parentHash, block.ParentHash)
 	}
-	if uint64(attrs.Timestamp) != block.Time() {
-		return fmt.Errorf("timestamp field does not match. expected: %v. got: %v", uint64(attrs.Timestamp), block.Time())
+	if attrs.Timestamp != block.Timestamp {
+		return fmt.Errorf("timestamp field does not match. expected: %v. got: %v", uint64(attrs.Timestamp), block.Timestamp)
 	}
-	if attrs.PrevRandao != l2.Bytes32(block.MixDigest()) {
-		return fmt.Errorf("random field does not match. expected: %v. got: %v", attrs.PrevRandao, l2.Bytes32(block.MixDigest()))
+	if attrs.PrevRandao != block.PrevRandao {
+		return fmt.Errorf("random field does not match. expected: %v. got: %v", attrs.PrevRandao, block.PrevRandao)
 	}
-	if len(attrs.Transactions) != len(block.Transactions()) {
-		return fmt.Errorf("transaction count does not match. expected: %v. got: %v", len(attrs.Transactions), len(block.Transactions()))
+	if len(attrs.Transactions) != len(block.Transactions) {
+		return fmt.Errorf("transaction count does not match. expected: %v. got: %v", len(attrs.Transactions), block.Transactions)
 	}
-	btxs := block.Transactions()
-	for i := range attrs.Transactions {
-		var tx types.Transaction
-		err := tx.UnmarshalBinary(attrs.Transactions[i])
-		if err != nil {
-			return fmt.Errorf("failed to decode transaction %d in attributes: %w", i, err)
-		}
-
-		if tx.Hash() != btxs[i].Hash() {
-			return fmt.Errorf("transaction %d does not match. expected: %v. got: %v", i, tx.Hash(), btxs[i].Hash())
+	for i, otx := range attrs.Transactions {
+		if expect := block.Transactions[i]; !bytes.Equal(otx, expect) {
+			return fmt.Errorf("transaction %d does not match. expected: %x. got: %x", i, expect, otx)
 		}
 	}
 	return nil
@@ -242,29 +236,28 @@ func attributesMatchBlock(attrs *l2.PayloadAttributes, parentHash common.Hash, b
 
 // verifySafeBlock reconciles the supplied payload attributes against the actual L2 block.
 // If they do not match, it inserts the new block and sets the head and safe head to the new block in the FC.
-func (d *outputImpl) verifySafeBlock(ctx context.Context, fc l2.ForkchoiceState, attrs *l2.PayloadAttributes, parent eth.BlockID) (derive.Block, bool, error) {
-	block, err := d.l2.BlockByNumber(ctx, new(big.Int).SetUint64(parent.Number+1))
+func (d *outputImpl) verifySafeBlock(ctx context.Context, fc l2.ForkchoiceState, attrs *l2.PayloadAttributes, parent eth.BlockID) (*l2.ExecutionPayload, bool, error) {
+	payload, err := d.l2.PayloadByNumber(ctx, new(big.Int).SetUint64(parent.Number+1))
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get L2 block: %w", err)
 	}
-	err = attributesMatchBlock(attrs, parent.Hash, block)
+	err = attributesMatchBlock(attrs, parent.Hash, payload)
 	if err != nil {
 		// Have reorg
-		d.log.Warn("Detected L2 reorg when verifying L2 safe head", "parent", parent, "prev_block", block.Hash(), "mismatch", err)
+		d.log.Warn("Detected L2 reorg when verifying L2 safe head", "parent", parent, "prev_block", payload.BlockHash, "mismatch", err)
 		fc.HeadBlockHash = parent.Hash
 		fc.SafeBlockHash = parent.Hash
 		payload, err := d.insertHeadBlock(ctx, fc, attrs, true)
 		return payload, true, err
 	}
-	// If match, just bump the safe head
-	d.log.Debug("Verified L2 block", "number", block.Number(), "hash", block.Hash())
-	fc.SafeBlockHash = block.Hash()
+	// If the attributes match, just bump the safe head
+	d.log.Debug("Verified L2 block", "number", payload.BlockNumber, "hash", payload.BlockHash)
+	fc.SafeBlockHash = payload.BlockHash
 	_, err = d.l2.ForkchoiceUpdate(ctx, &fc, nil)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to execute ForkchoiceUpdated: %w", err)
 	}
-	return block, false, nil
-
+	return payload, false, nil
 }
 
 // insertHeadBlock creates, executes, and inserts the specified block as the head block.


### PR DESCRIPTION
Previously there were many issues with encoding/decoding transactions:
- first it would fetch the block
- then it would decode the txs
- then it would encode the txs back, and hash them, to compare the equality of attributes
- then it would compare them
- and then it derived the L1 info from the first block

Instead, we should hide all this from the driver, and expose methods that do the most minimal thing:
- Provide execution payloads when necessary to compare against attributes (on reorgs)
- Provide L2 block ref without doing all tx decoding/encoding work, we only need the first
- Provide a method to compute the L2-block ref from a payload, without fuly decoding the payload. We don't need to go back/forth to fully parsed txs when we're dealing with a payload that we produced with the engine api

And now that it's more encapsulated, I hope we can optimize the L2 engine api client with caching (avoid repeated requests) and more light-weight json parsing (we're still fetching decoded block data from the RPC, there should be a way to fetch a block with the raw transaction data, to avoid lots of unnecessary work) 

This also gets rid of the transactions decoding panic, and removes the need for an interface that wraps both `types.Block` and `l2.ExecutionPayload`