### PR TITLE
opnode,l2os: Better lifecycle management

### DIFF
--- a/opnode/test/setup.go
+++ b/opnode/test/setup.go
@@ -117,11 +117,11 @@ func (cfg SystemConfig) start() (*System, error) {
 	didErrAfterStart := false
 	defer func() {
 		if didErrAfterStart {
-			for _, node := range sys.nodes {
-				node.Close()
-			}
 			for _, node := range sys.rollupNodes {
 				node.Stop()
+			}
+			for _, node := range sys.nodes {
+				node.Close()
 			}
 		}
 	}()


### PR DESCRIPTION
**Description**

This changes the order of shutdowns to be correct (rollup nodes prior to clients) as well as making sure that all ethclients are shut down.

**Metadata**

Fixes https://github.com/ethereum-optimism/optimistic-specs/pull/319
