### PR TITLE
opnode: Parameterize deposit contract address

### DIFF
--- a/opnode/rollup/derive/invert_test.go
+++ b/opnode/rollup/derive/invert_test.go
@@ -103,6 +103,8 @@ type infoTest struct {
 	mkInfo func(rng *rand.Rand) *l1MockInfo
 }
 
+var MockDepositContractAddr = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
+
 func TestParseL1InfoDepositTxData(t *testing.T) {
 	// Go 1.18 will have native fuzzing for us to use, until then, we cover just the below cases
 	cases := []infoTest{
@@ -123,7 +125,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 	for i, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
 			info := testCase.mkInfo(rand.New(rand.NewSource(int64(1234 + i))))
-			depTx := L1InfoDeposit(123, info)
+			depTx := L1InfoDeposit(123, info, MockDepositContractAddr)
 			nr, time, baseFee, h, err := L1InfoDepositTxData(depTx.Data)
 			assert.NoError(t, err, "expected valid deposit info")
 			assert.Equal(t, nr, info.num)

--- a/opnode/rollup/derive/payload_attributes_test.go
+++ b/opnode/rollup/derive/payload_attributes_test.go
@@ -93,7 +93,7 @@ func GenerateDepositLog(deposit *types.DepositTx) *types.Log {
 		data = append(data, make([]byte, 32-(len(data)%32))...)
 	}
 
-	return GenerateLog(DepositContractAddr, topics, data)
+	return GenerateLog(MockDepositContractAddr, topics, data)
 }
 
 // Generates an EVM log entry with the given topics and data.
@@ -204,7 +204,7 @@ func TestDeriveUserDeposits(t *testing.T) {
 					TransactionIndex: uint(txIndex),
 				})
 			}
-			got, err := UserDeposits(receipts)
+			got, err := UserDeposits(receipts, MockDepositContractAddr)
 			assert.NoError(t, err)
 			assert.Equal(t, len(got), len(expectedDeposits))
 			for d, depTx := range got {

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -81,7 +81,7 @@ func (d *outputImpl) createNewBlock(ctx context.Context, l2Head eth.L2BlockRef, 
 
 	// First transaction in every block is always the L1 info transaction.
 	seqNumber := l2Head.Number + 1 - l2SafeHead.Number
-	l1InfoTx, err := derive.L1InfoDepositBytes(seqNumber, l1Info)
+	l1InfoTx, err := derive.L1InfoDepositBytes(seqNumber, l1Info, d.Config.DepositContractAddress)
 	if err != nil {
 		return l2Head, nil, err
 	}
@@ -89,7 +89,7 @@ func (d *outputImpl) createNewBlock(ctx context.Context, l2Head eth.L2BlockRef, 
 
 	// Next we append user deposits. If we're not the first block in an epoch, then receipts will
 	// be empty and no deposits will be derived.
-	deposits, err := derive.DeriveDeposits(receipts)
+	deposits, err := derive.DeriveDeposits(receipts, d.Config.DepositContractAddress)
 	d.log.Info("Derived deposits", "deposits", deposits, "l2Parent", l2Head, "l1Origin", l1Origin)
 	if err != nil {
 		return l2Head, nil, fmt.Errorf("failed to derive deposits: %v", err)
@@ -175,7 +175,7 @@ func (d *outputImpl) insertEpoch(ctx context.Context, l2Head eth.L2BlockRef, l2S
 	if err != nil {
 		return l2Head, l2SafeHead, false, fmt.Errorf("failed to get L1 timestamp of next L1 block: %v", err)
 	}
-	deposits, err := derive.DeriveDeposits(receipts)
+	deposits, err := derive.DeriveDeposits(receipts, d.Config.DepositContractAddress)
 	if err != nil {
 		return l2Head, l2SafeHead, false, fmt.Errorf("failed to derive deposits: %w", err)
 	}
@@ -210,7 +210,7 @@ func (d *outputImpl) insertEpoch(ctx context.Context, l2Head eth.L2BlockRef, l2S
 	var reorg bool
 	for i, batch := range batches {
 		var txns []l2.Data
-		l1InfoTx, err := derive.L1InfoDepositBytes(uint64(i), l1Info)
+		l1InfoTx, err := derive.L1InfoDepositBytes(uint64(i), l1Info, d.Config.DepositContractAddress)
 		if err != nil {
 			return l2Head, l2SafeHead, false, fmt.Errorf("failed to create l1InfoTx: %w", err)
 		}

--- a/opnode/rollup/types.go
+++ b/opnode/rollup/types.go
@@ -44,6 +44,8 @@ type Config struct {
 	BatchInboxAddress common.Address `json:"batch_inbox_address"`
 	// Acceptable batch-sender address
 	BatchSenderAddress common.Address `json:"batch_sender_address"`
+	// L1 Deposit Contract Address
+	DepositContractAddress common.Address `json:"deposit_contract_address"`
 }
 
 // Check verifies that the given configuration makes sense
@@ -62,6 +64,9 @@ func (cfg *Config) Check() error {
 	}
 	if cfg.Genesis.L2.Hash == cfg.Genesis.L1.Hash {
 		return errors.New("achievement get! rollup inception: L1 and L2 genesis cannot be the same")
+	}
+	if cfg.DepositContractAddress == (common.Address{}) {
+		return errors.New("did not provide deposit contract address ")
 	}
 	return nil
 }

--- a/opnode/test/system_test.go
+++ b/opnode/test/system_test.go
@@ -31,6 +31,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Temporary until the contract is deployed properly instead of as a pre-deploy to a specific address
+var MockDepositContractAddr = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
+
 const (
 	cliqueSignerHDPath = "m/44'/60'/0'/0/0"
 	transactorHDPath   = "m/44'/60'/0'/0/1"
@@ -49,7 +52,7 @@ func defaultSystemConfig(t *testing.T) SystemConfig {
 		},
 		BatchSubmitterHDPath:       bssHDPath,
 		CliqueSignerDerivationPath: cliqueSignerHDPath,
-		DepositContractAddress:     derive.DepositContractAddr,
+		DepositContractAddress:     MockDepositContractAddr,
 		L1InfoPredeployAddress:     derive.L1InfoPredeployAddr,
 		L1WsAddr:                   "127.0.0.1",
 		L1WsPort:                   9090,
@@ -86,6 +89,7 @@ func defaultSystemConfig(t *testing.T) SystemConfig {
 			FeeRecipientAddress: common.Address{0xff, 0x01},
 			BatchInboxAddress:   common.Address{0xff, 0x02},
 			// Batch Sender address is filled out in system start
+			DepositContractAddress: MockDepositContractAddr,
 		},
 	}
 }

--- a/ops/rollup.json
+++ b/ops/rollup.json
@@ -23,5 +23,7 @@
 
   "batch_inbox_address":  "0xff00000000000000000000000000000000000002",
 
-  "batch_sender_address": "0xde3829a23df1479438622a08a116e8eb3f620bb5"
+  "batch_sender_address": "0xde3829a23df1479438622a08a116e8eb3f620bb5",
+
+  "deposit_contract_address": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"
 }


### PR DESCRIPTION
The contract can be deployed to any address. It is set in the rollup config file.

