### PR TITLE
fix(ci): use Foundry GHA

### DIFF
--- a/.github/workflows/devnet-ci.yml
+++ b/.github/workflows/devnet-ci.yml
@@ -23,12 +23,10 @@ jobs:
           node-version: '14'
           cache: 'yarn'
 
-      - run: |
-          curl -L -o /tmp/foundry.tgz https://github.com/gakonst/foundry/releases/download/nightly-9c2469488c6872e5d17198555f7d8e1a80173151/foundry_nightly_linux_amd64.tar.gz
-          tar -xzvf /tmp/foundry.tgz
-          mv forge /usr/local/bin
-          mv cast /usr/local/bin
-        name: Install forge
+      - name: Install Foundry
+        uses: onbjerg/foundry-toolchain@v1
+        with:
+          version: nightly
 
       - run: cd packages/contracts && yarn install && yarn build
       - run: cd packages/integration-tests && yarn install && yarn build:contracts


### PR DESCRIPTION
Nightly Foundry releases are kept around for 3 days. This means we cannot be pinning the download link on CI to a specific commit.

Instead, we use the Foundry Toolchain GHA which always uses the latest nightly version.