### PR TITLE
contracts: reuse code

### DIFF
--- a/packages/contracts/.gas-snapshot
+++ b/packages/contracts/.gas-snapshot
@@ -28,5 +28,5 @@ WithdrawalsRelay_finalizeWithdrawalTransaction_Test:test_cannotVerifyInvalidProo
 WithdrawalsRelay_finalizeWithdrawalTransaction_Test:test_cannotVerifyRecentWithdrawal() (gas: 39686)
 WithdrawalsRelay_finalizeWithdrawalTransaction_Test:test_verifyWithdrawal() (gas: 200110)
 WithdawerBurnTest:test_burn() (gas: 50276)
-WithdrawerTestInitiateWithdrawal:test_initiateWithdrawal_fromContract() (gas: 71947)
-WithdrawerTestInitiateWithdrawal:test_initiateWithdrawal_fromEOA() (gas: 72412)
+WithdrawerTestInitiateWithdrawal:test_initiateWithdrawal_fromContract() (gas: 72023)
+WithdrawerTestInitiateWithdrawal:test_initiateWithdrawal_fromEOA() (gas: 72488)

--- a/packages/contracts/contracts/L1/abstracts/WithdrawalsRelay.sol
+++ b/packages/contracts/contracts/L1/abstracts/WithdrawalsRelay.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.10;
 import { L2OutputOracle } from "../L2OutputOracle.sol";
 
 /* Library Imports */
-import { WithdrawalVerifier } from "../libraries/Lib_WithdrawalVerifier.sol";
+import { WithdrawalVerifier } from "../../libraries/Lib_WithdrawalVerifier.sol";
 
 /**
  * @title WithdrawalsRelay

--- a/packages/contracts/contracts/L2/Withdrawer.sol
+++ b/packages/contracts/contracts/L2/Withdrawer.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.10;
 import {
     AddressAliasHelper
 } from "../../lib/optimism/packages/contracts/contracts/standards/AddressAliasHelper.sol";
+import { WithdrawalVerifier } from "../libraries/Lib_WithdrawalVerifier.sol";
 
 /* Interaction imports */
 import { Burner } from "./Burner.sol";
@@ -70,8 +71,13 @@ contract Withdrawer {
         if (msg.sender != tx.origin) {
             from = AddressAliasHelper.undoL1ToL2Alias(msg.sender);
         }
-        bytes32 withdrawalHash = keccak256(
-            abi.encode(nonce, msg.sender, _target, msg.value, _gasLimit, _data)
+        bytes32 withdrawalHash = WithdrawalVerifier._deriveWithdrawalHash(
+            nonce,
+            msg.sender,
+            _target,
+            msg.value,
+            _gasLimit,
+            _data
         );
         withdrawals[withdrawalHash] = true;
 

--- a/packages/contracts/contracts/libraries/Lib_WithdrawalVerifier.sol
+++ b/packages/contracts/contracts/libraries/Lib_WithdrawalVerifier.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 /* Library Imports */
 import {
     Lib_SecureMerkleTrie
-} from "../../../lib/optimism/packages/contracts/contracts/libraries/trie/Lib_SecureMerkleTrie.sol";
+} from "../../lib/optimism/packages/contracts/contracts/libraries/trie/Lib_SecureMerkleTrie.sol";
 
 /**
  * @title WithdrawalVerifier

--- a/packages/contracts/contracts/test/WithdrawalsRelay.t.sol
+++ b/packages/contracts/contracts/test/WithdrawalsRelay.t.sol
@@ -7,7 +7,7 @@ import { Vm } from "../../lib/forge-std/src/Vm.sol";
 
 /* Target contract dependencies */
 import { L2OutputOracle } from "../L1/L2OutputOracle.sol";
-import { WithdrawalVerifier } from "../L1/libraries/Lib_WithdrawalVerifier.sol";
+import { WithdrawalVerifier } from "../libraries/Lib_WithdrawalVerifier.sol";
 
 /* Target contract */
 import { WithdrawalsRelay } from "../L1/abstracts/WithdrawalsRelay.sol";


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Reuse the `WithdrawalVerifier` library in both the L1 and L2 contracts. I figure that we might as well use the same code on both sides of the bridge to ensure that its computed exactly the same way. It does seem to increase gas usage a little bit.

