### PR TITLE
Makefile,ops: docker compose up instead of run to make devnet-down work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ devnet-up:
 
 devnet-down:
 	@(cd ./ops && GENESIS_TIMESTAMP=$(shell date +%s) docker-compose stop)
-.PHONY: devnet-stop
+.PHONY: devnet-down
 
 devnet-clean:
 	rm -rf ./packages/contracts/deployments/devnetL1

--- a/ops/devnet-up.sh
+++ b/ops/devnet-up.sh
@@ -137,10 +137,8 @@ jq ". | .genesis.l1.hash = \"$(echo $L1_GENESIS | jq -r '.result.hash')\"" < ./o
 
 # Bring up everything else.
 cd ops
-echo "Bringing up rollup node..."
-docker-compose up -d opnode
-echo "Bringing up output submitter..."
-docker-compose run -e L2OO_ADDRESS="$L2OO_ADDRESS" -d --name ops-l2os-1 l2os
+echo "Bringing up devnet..."
+L2OO_ADDRESS="$L2OO_ADDRESS" docker-compose up -d l2os
 cd ../
 
 echo "Devnet ready."

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -70,3 +70,4 @@ services:
       OUTPUT_SUBMITTER_RESUBMISSION_TIMEOUT: 30s
       OUTPUT_SUBMITTER_MNEMONIC: test test test test test test test test test test test junk
       OUTPUT_SUBMITTER_L2_OUTPUT_HD_PATH: "m/44'/60'/0'/0/1"
+      L2OO_ADDRESS: "${L2OO_ADDRESS}"


### PR DESCRIPTION
Minor fixes to makefile and devnet-up.sh, to make devnet-down work as expected. Previously the `ops_l2os_1` container wasn't being shut down because it was started separately (presumably because of env var option, but fixed that by passing along the env var in the yml environment definition).

