### PR TITLE
opnode: Fix L1 Info Transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.10.16 => github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220411203319-ad60590374c8
+replace github.com/ethereum/go-ethereum v1.10.16 => github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220427171107-d0070e0a6ead
 
 // For local debugging:
-//replace github.com/ethereum/go-ethereum v1.10.16 => ../go-ethereum
+// replace github.com/ethereum/go-ethereum v1.10.16 => ../go-ethereum

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220411203319-ad60590374c8 h1:GrJtCdIozmrjTDrt/4PLwtVMkF3xYtgVVfnJb14gm+Y=
-github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220411203319-ad60590374c8/go.mod h1:m2COxrfN3y8Yc0+FBC04+TVGFq9cAgxGO2QsEiiBYJM=
+github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220427171107-d0070e0a6ead h1:AiLggtwXHmAGxNusOEH7edb83TtJnavtR2uY1z6YzYc=
+github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220427171107-d0070e0a6ead/go.mod h1:m2COxrfN3y8Yc0+FBC04+TVGFq9cAgxGO2QsEiiBYJM=
 github.com/ethereum/go-ethereum v1.10.4/go.mod h1:nEE0TP5MtxGzOMd7egIrbPJMQBnhVU3ELNxhBglIzhg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=

--- a/opnode/rollup/derive/invert.go
+++ b/opnode/rollup/derive/invert.go
@@ -1,26 +1,58 @@
 package derive
 
 import (
-	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// setL1BlockValues(uint256 _number, uint256 _timestamp, uint256 _basefee, bytes32 _hash)
+type L1BlockInfo struct {
+	Number    uint64
+	Time      uint64
+	BaseFee   *big.Int
+	BlockHash common.Hash
+}
+
 // L1InfoDepositTxData is the inverse of L1InfoDeposit, to see where the L2 chain is derived from
 func L1InfoDepositTxData(data []byte) (nr uint64, time uint64, baseFee *big.Int, blockHash common.Hash, err error) {
-	if len(data) != 4+8+8+32+32 {
-		err = fmt.Errorf("data is unexpected length: %d", len(data))
-		return
+	info, err := L1InfoDepositTxDataToStruct(data)
+	return info.Number, info.Time, info.BaseFee, info.BlockHash, err
+}
+
+// L1InfoDepositTxDataToStruct is the inverse of L1InfoDeposit, to see where the L2 chain is derived from
+func L1InfoDepositTxDataToStruct(data []byte) (L1BlockInfo, error) {
+	out := L1BlockInfo{}
+	if len(data) != 4+32+32+32+32 {
+		return out, fmt.Errorf("data is unexpected length: %d", len(data))
 	}
-	offset := 4
-	nr = binary.BigEndian.Uint64(data[offset : offset+8])
-	offset += 8
-	time = binary.BigEndian.Uint64(data[offset : offset+8])
-	offset += 8
-	baseFee = new(big.Int).SetBytes(data[offset : offset+32])
+
+	// Number
+	offset := 4 // Selector hash. Should check
+	number := new(big.Int)
+	number.SetBytes(data[offset : offset+32])
+	if !number.IsUint64() {
+		return L1BlockInfo{}, errors.New("number does not fit in uint64")
+	}
+	out.Number = number.Uint64()
+
+	// Timestamp
 	offset += 32
-	blockHash.SetBytes(data[offset : offset+32])
-	return
+	timestamp := new(big.Int)
+	timestamp.SetBytes(data[offset : offset+32])
+	if !timestamp.IsUint64() {
+		return L1BlockInfo{}, errors.New("timestamp does not fit in uint64")
+	}
+	out.Time = timestamp.Uint64()
+
+	// BaseFee
+	offset += 32
+	out.BaseFee = new(big.Int).SetBytes(data[offset : offset+32])
+
+	// Hash
+	offset += 32
+	out.BlockHash.SetBytes(data[offset : offset+32])
+	return out, nil
 }

--- a/opnode/rollup/derive/invert_test.go
+++ b/opnode/rollup/derive/invert_test.go
@@ -103,7 +103,7 @@ type infoTest struct {
 	mkInfo func(rng *rand.Rand) *l1MockInfo
 }
 
-var MockDepositContractAddr = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
+var MockDepositContractAddr = common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeef00000000")
 
 func TestParseL1InfoDepositTxData(t *testing.T) {
 	// Go 1.18 will have native fuzzing for us to use, until then, we cover just the below cases
@@ -125,7 +125,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 	for i, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
 			info := testCase.mkInfo(rand.New(rand.NewSource(int64(1234 + i))))
-			depTx := L1InfoDeposit(123, info, MockDepositContractAddr)
+			depTx := L1InfoDeposit(123, info)
 			nr, time, baseFee, h, err := L1InfoDepositTxData(depTx.Data)
 			assert.NoError(t, err, "expected valid deposit info")
 			assert.Equal(t, nr, info.num)

--- a/opnode/rollup/driver/step.go
+++ b/opnode/rollup/driver/step.go
@@ -81,7 +81,7 @@ func (d *outputImpl) createNewBlock(ctx context.Context, l2Head eth.L2BlockRef, 
 
 	// First transaction in every block is always the L1 info transaction.
 	seqNumber := l2Head.Number + 1 - l2SafeHead.Number
-	l1InfoTx, err := derive.L1InfoDepositBytes(seqNumber, l1Info, d.Config.DepositContractAddress)
+	l1InfoTx, err := derive.L1InfoDepositBytes(seqNumber, l1Info)
 	if err != nil {
 		return l2Head, nil, err
 	}
@@ -212,7 +212,7 @@ func (d *outputImpl) insertEpoch(ctx context.Context, l2Head eth.L2BlockRef, l2S
 	var reorg bool
 	for i, batch := range batches {
 		var txns []l2.Data
-		l1InfoTx, err := derive.L1InfoDepositBytes(uint64(i), l1Info, d.Config.DepositContractAddress)
+		l1InfoTx, err := derive.L1InfoDepositBytes(uint64(i), l1Info)
 		if err != nil {
 			return l2Head, l2SafeHead, false, fmt.Errorf("failed to create l1InfoTx: %w", err)
 		}


### PR DESCRIPTION
There are three issues being fixed:
1. Set the `from` field to the correct magic value (found by ToB)
2. Update the L2 EE to provide gas to deposits. Otherwise the
   deposit transactions immediatley out of gas and fail.
3. Update the manual ABI encoding to match what solidity expects.
   The previous version was similar to packed encodeding, but as
   such could not be parsed by solidity.

This also includes a regression test that the parsing of the L1 info
tx and what is recorded in the state for each block matches.


