### PR TITLE
contracts: fix abi encoding in proof verification

### DIFF
--- a/packages/contracts/contracts/libraries/Lib_WithdrawalVerifier.sol
+++ b/packages/contracts/contracts/libraries/Lib_WithdrawalVerifier.sol
@@ -82,7 +82,7 @@ library WithdrawalVerifier {
 
         return
             Lib_SecureMerkleTrie.verifyInclusionProof(
-                abi.encodePacked(storageKey),
+                abi.encode(storageKey),
                 hex"01",
                 _withdrawalProof,
                 _withdrawerStorageRoot


### PR DESCRIPTION
**Description**

Use `abi.encode` instead of `abi.encodePacked` to ensure
a constant serialization. `abi.encode` will be sure to
pad the value to its size while `abi.encodePacked` will not
when operating on integers. There should not have been a bug here
because it was being called with a `bytes32`, which should
always be 32 bytes when returned from `abi.encodePacked`.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

