### PR TITLE
opnode: Avoid busy-waiting while L2 head is behind L1

### DIFF
--- a/opnode/rollup/driver/state.go
+++ b/opnode/rollup/driver/state.go
@@ -352,7 +352,8 @@ func (s *state) loop() {
 			// TODO: If we want to consider confirmations, need to consider here too.
 			if s.l1Head.Number > s.l2Head.L1Origin.Number {
 				s.log.Trace("Asking for a second L2 block asap", "l2Head", s.l2Head)
-				reqL2BlockCreation()
+				// But not too quickly to minimize busy-waiting for new blocks
+				time.AfterFunc(time.Millisecond*10, reqL2BlockCreation)
 			}
 
 		case newL1Head := <-s.l1Heads:


### PR DESCRIPTION
In the state select loop, we immediately request for new L2 blocks whenever
the latest L1 origin is behind L1. This can be an issue as we attempt to
re-request the latest L2 block without any delay. This is a DoS hazard
particularly when an L2 block cannot be retrieved because either the `L1Chain`
or `L2Chain` backends have errors.

Another problem with this is that other, more useful events in the state
select loop, are less likely to be scheduled by the Go runtime due to
the busy-wait.

Adding a small delay, before calling `reql2BlockCreation` of about 10ms
should be enough to prevent issues.