### PR TITLE
test: Enable contract creation through a deposit test

### DIFF
--- a/packages/integration-tests/test/deposit.spec.ts
+++ b/packages/integration-tests/test/deposit.spec.ts
@@ -59,7 +59,7 @@ describe('Deposits', () => {
     })
   }).timeout(60_000)
 
-  it.skip('should deposit a contract creation', async () => {
+  it('should deposit a contract creation', async () => {
     const value = utils.parseEther('0.1')
     const factory = new ContractFactory(
       counterArtifact.abi,


### PR DESCRIPTION
**Description**
This was failing due to deposits not getting any gas. This was fixed
in https://github.com/ethereum-optimism/optimistic-specs/pull/386.
