### PR TITLE
specs: deposits pay gas on L1

### DIFF
--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -50,6 +50,7 @@ transaction types:
 1. They are derived from Layer 1 blocks, and must be included as part of the protocol.
 2. They do not include signature validation (see [User-Deposited Transactions][user-deposited]
    for the rationale).
+3. They do not pay for gas on layer 2 and are metered on layer 1
 
 We define a new [EIP-2718] compatible transaction type with the prefix `0x7E`, and the following
 fields (rlp encoded in the order they appear here):


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
I didn't notice anywhere in the specs where it is clearly mentioned that deposits are not charged for gas on L2. Correct me if I am wrong, but we are not going with the additional gas scheme so now the only way that deposits are metered is based on the L1 eip1159 curve in the deposit contract
