### PR TITLE
P2P discovery

### DIFF
--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -144,7 +144,7 @@ var (
 	}
 	UserAgent = cli.StringFlag{
 		Name:     "p2p.useragent",
-		Usage:    "User-agent string to share via LibP2P identify. If empty it defaults to 'optimism-VERSIONHERE'.",
+		Usage:    "User-agent string to share via LibP2P identify. If empty it defaults to 'optimism'.",
 		Hidden:   true,
 		Required: false,
 		Value:    "optimism",

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -34,7 +34,7 @@ type OpNode struct {
 	l2Engines  []*driver.Driver      // engines to keep synced
 	l2Nodes    []*rpc.Client         // L2 Execution Engines to close at shutdown
 	server     *rpcServer            // RPC server hosting the rollup-node API
-	p2pNode    p2p.Node              // P2P node functionality
+	p2pNode    *p2p.NodeP2P          // P2P node functionality
 	p2pSigner  p2p.Signer            // p2p gogssip application messages will be signed with this signer
 	tracer     Tracer                // tracer to get events for testing/debugging
 
@@ -221,6 +221,9 @@ func (n *OpNode) initP2P(ctx context.Context, cfg *Config) error {
 			return err
 		}
 		n.p2pNode = p2pNode
+		if n.p2pNode.Dv5Udp() != nil {
+			n.p2pNode.DiscoveryProcess(n.resourcesCtx, n.log, &cfg.Rollup, cfg.P2P.TargetPeers())
+		}
 	}
 	return nil
 }

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -222,7 +222,7 @@ func (n *OpNode) initP2P(ctx context.Context, cfg *Config) error {
 		}
 		n.p2pNode = p2pNode
 		if n.p2pNode.Dv5Udp() != nil {
-			n.p2pNode.DiscoveryProcess(n.resourcesCtx, n.log, &cfg.Rollup, cfg.P2P.TargetPeers())
+			go n.p2pNode.DiscoveryProcess(n.resourcesCtx, n.log, &cfg.Rollup, cfg.P2P.TargetPeers())
 		}
 	}
 	return nil

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -44,7 +46,8 @@ type SetupP2P interface {
 	// Host creates a libp2p host service. Returns nil, nil if p2p is disabled.
 	Host(log log.Logger) (host.Host, error)
 	// Discovery creates a disc-v5 service. Returns nil, nil, nil if discovery is disabled.
-	Discovery(log log.Logger) (*enode.LocalNode, *discover.UDPv5, error)
+	Discovery(log log.Logger, rollupCfg *rollup.Config) (*enode.LocalNode, *discover.UDPv5, error)
+	TargetPeers() uint
 }
 
 // Config sets up a p2p host and discv5 service from configuration.
@@ -173,6 +176,10 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	conf.ConnMngr = DefaultConnManager
 
 	return conf, nil
+}
+
+func (conf *Config) TargetPeers() uint {
+	return conf.PeersLo
 }
 
 func (conf *Config) loadListenOpts(ctx *cli.Context) error {

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 
@@ -46,7 +46,7 @@ type SetupP2P interface {
 	// Host creates a libp2p host service. Returns nil, nil if p2p is disabled.
 	Host(log log.Logger) (host.Host, error)
 	// Discovery creates a disc-v5 service. Returns nil, nil, nil if discovery is disabled.
-	Discovery(log log.Logger, rollupCfg *rollup.Config) (*enode.LocalNode, *discover.UDPv5, error)
+	Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort uint16) (*enode.LocalNode, *discover.UDPv5, error)
 	TargetPeers() uint
 }
 

--- a/op-node/p2p/discovery.go
+++ b/op-node/p2p/discovery.go
@@ -1,14 +1,30 @@
 package p2p
 
 import (
+	"bytes"
+	"context"
+	secureRand "crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/rand"
 	"net"
+	"time"
+
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
-func (conf *Config) Discovery(log log.Logger) (*enode.LocalNode, *discover.UDPv5, error) {
+func (conf *Config) Discovery(log log.Logger, rollupCfg *rollup.Config) (*enode.LocalNode, *discover.UDPv5, error) {
 	if conf.NoDiscovery {
 		return nil, nil, nil
 	}
@@ -19,6 +35,11 @@ func (conf *Config) Discovery(log log.Logger) (*enode.LocalNode, *discover.UDPv5
 	if conf.AdvertiseUDPPort != 0 {
 		localNode.SetFallbackUDP(int(conf.AdvertiseUDPPort))
 	}
+	dat := OptimismENRData{
+		chainID: rollupCfg.L2ChainID.Uint64(),
+		version: 0,
+	}
+	localNode.Set(&dat)
 
 	udpAddr := &net.UDPAddr{
 		IP:   conf.ListenIP,
@@ -47,4 +68,204 @@ func (conf *Config) Discovery(log log.Logger) (*enode.LocalNode, *discover.UDPv5
 	// and add it as a statement to keep the localNode accurate (if we trust the NAT device more than the discv5 statements)
 
 	return localNode, udpV5, nil
+}
+
+func enrToAddrInfo(r *enode.Node) (*peer.AddrInfo, error) {
+	ip := r.IP()
+	ipScheme := "ip4"
+	if ip4 := ip.To4(); ip4 == nil {
+		ipScheme = "ip6"
+	} else {
+		ip = ip4
+	}
+	mAddr, err := ma.NewMultiaddr(fmt.Sprintf("/%s/%s/tcp/%d", ipScheme, ip.String(), r.TCP()))
+	if err != nil {
+		return nil, fmt.Errorf("could not construct multi addr: %v", err)
+	}
+	pub := r.Pubkey()
+	peerID, err := peer.IDFromPublicKey((*crypto.Secp256k1PublicKey)(pub))
+	if err != nil {
+		return nil, fmt.Errorf("could not compute peer ID from pubkey for multi-addr: %v", err)
+	}
+	return &peer.AddrInfo{
+		ID:    peerID,
+		Addrs: []ma.Multiaddr{mAddr},
+	}, nil
+}
+
+// The discovery ENRs are just key-value lists, and we filter them by records tagged with the "optimism" key,
+// and then check the chain ID and version.
+type OptimismENRData struct {
+	chainID uint64
+	version uint64
+}
+
+func (o *OptimismENRData) ENRKey() string {
+	return "optimism"
+}
+
+func (o *OptimismENRData) DecodeRLP(s *rlp.Stream) error {
+	b, err := s.Bytes()
+	if err != nil {
+		return fmt.Errorf("failed to decode outer ENR entry: %v", err)
+	}
+	// We don't check the byte length: the below readers are limited, and the ENR itself has size limits.
+	// Future "optimism" entries may contain additional data, and will be tagged with a newer version etc.
+	r := bytes.NewReader(b)
+	chainID, err := binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("failed to read chain ID var int: %v", err)
+	}
+	version, err := binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("failed to read version var int: %v", err)
+	}
+	o.chainID = chainID
+	o.version = version
+	return nil
+}
+
+var _ enr.Entry = (*OptimismENRData)(nil)
+
+func FilterEnodes(cfg *rollup.Config) func(node *enode.Node) bool {
+	return func(node *enode.Node) bool {
+		var dat OptimismENRData
+		err := node.Load(&dat)
+		// if the entry does not exist, or if it is invalid, then ignore the node
+		if err != nil {
+			return false
+		}
+		// check chain ID matches
+		if cfg.L2ChainID.Uint64() != dat.chainID {
+			return false
+		}
+		// check version matches
+		if dat.version != 0 {
+			return false
+		}
+		return true
+	}
+}
+
+// DiscoveryProcess runs a discovery process that randomly walks the DHT to fill the peerstore,
+// and connects to nodes in the peerstore that we are not already connected to.
+// Nodes from the peerstore will be shuffled, unsuccessful connection attempts will cause peers to be avoided,
+// and only nodes with addresses (under TTL) will be connected to.
+func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, cfg *rollup.Config, connectGoal uint) {
+	if n.dv5Udp == nil {
+		log.Warn("peer discovery is disabled")
+		return
+	}
+	randomNodeIter := n.dv5Udp.RandomNodes()
+	randomNodeIter = enode.Filter(randomNodeIter, FilterEnodes(cfg))
+
+	discoverTicker := time.NewTicker(time.Second * 5)
+	defer discoverTicker.Stop()
+
+	connectTicker := time.NewTicker(time.Second * 20)
+	defer connectTicker.Stop()
+
+	connAttempts := make(chan peer.ID, 10)
+
+	connectWorker := func(ctx context.Context) {
+		for {
+			id, ok := <-connAttempts
+			if !ok {
+				return
+			}
+			addrs := n.Host().Peerstore().Addrs(id)
+			log.Info("attempting connection", "peer", id)
+			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+			err := n.Host().Connect(ctx, peer.AddrInfo{ID: id, Addrs: addrs})
+			cancel()
+			if err != nil {
+				log.Debug("failed connection attempt", "peer", id, "err", err)
+			}
+		}
+	}
+	// stops all the workers when we are done
+	defer close(connAttempts)
+	// start workers to try connect to peers
+	for i := 0; i < 4; i++ {
+		go connectWorker(ctx)
+	}
+
+	pstore := n.Host().Peerstore()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("stopped peer discovery")
+			return // no ctx error, expected close
+		case <-discoverTicker.C:
+			if !randomNodeIter.Next() {
+				log.Info("discv5 DHT iteration stopped, closing peer discovery now...")
+				return
+			}
+			found := randomNodeIter.Node()
+			var dat OptimismENRData
+			if err := found.Load(&dat); err != nil { // we already filtered on chain ID and version
+				continue
+			}
+			info, err := enrToAddrInfo(found)
+			if err != nil {
+				continue
+			}
+			// We add the addresses to the peerstore, and update the address TTL to 24 hours.
+			//After that we stop using the address, assuming it may not be valid anymore (until we rediscover the node)
+			pstore.AddAddrs(info.ID, info.Addrs, time.Hour*24)
+			_ = pstore.AddPubKey(info.ID, (*crypto.Secp256k1PublicKey)(found.Pubkey()))
+			// Tag the peer, we'd rather have the connection manager prune away old peers,
+			// or peers on different chains, or anyone we have not seen via discovery.
+			// There is no tag score decay yet, so just set it to 42.
+			n.ConnectionManager().TagPeer(info.ID, fmt.Sprintf("optimism-%d-%d", dat.chainID, dat.version), 42)
+			log.Debug("discovered peer", "peer", info.ID, "nodeID", found.ID(), "addr", info.Addrs[0])
+		case <-connectTicker.C:
+			connected := n.Host().Network().Peers()
+			if uint(len(connected)) < connectGoal {
+				peersWithAddrs := n.Host().Peerstore().PeersWithAddrs()
+				if err := shufflePeers(peersWithAddrs); err != nil {
+					continue
+				}
+
+				existing := make(map[peer.ID]struct{})
+				for _, p := range connected {
+					existing[p] = struct{}{}
+				}
+
+				// For 30 seconds, keep using these peers, and don't try new discovery/connections.
+				// We don't need to search for more peers and try new connections if we already have plenty
+				ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+				// connect to 4 peers in parallel
+			peerLoop:
+				for _, id := range peersWithAddrs {
+					// skip peers that we are already connected to
+					if _, ok := existing[id]; ok {
+						continue
+					}
+					// skip peers that we were just connected to
+					if n.Host().Network().Connectedness(id) == network.CannotConnect {
+						continue
+					}
+					// schedule, if there is still space to schedule
+					select {
+					case connAttempts <- id:
+					case <-ctx.Done():
+						break peerLoop
+					}
+				}
+				cancel()
+			}
+		}
+	}
+}
+
+// shuffle the slice of peer IDs in-place with a RNG seeded by secure randomness.
+func shufflePeers(ids peer.IDSlice) error {
+	var x [8]byte // shuffling is not critical, just need to avoid basic predictability by outside peers
+	if _, err := io.ReadFull(secureRand.Reader, x[:]); err != nil {
+		return err
+	}
+	rng := rand.New(rand.NewSource(int64(binary.LittleEndian.Uint64(x[:]))))
+	rng.Shuffle(len(ids), ids.Swap)
+	return nil
 }

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -47,7 +47,7 @@ func NewNodeP2P(resourcesCtx context.Context, rollupCfg *rollup.Config, log log.
 func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.Config, log log.Logger, setup SetupP2P, gossipIn GossipIn) error {
 	var err error
 	// All nil if disabled.
-	n.dv5Local, n.dv5Udp, err = setup.Discovery(log.New("p2p", "discv5"))
+	n.dv5Local, n.dv5Udp, err = setup.Discovery(log.New("p2p", "discv5"), rollupCfg)
 	if err != nil {
 		return fmt.Errorf("failed to start discv5: %v", err)
 	}

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+
+	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/log"
@@ -17,13 +20,14 @@ import (
 )
 
 type NodeP2P struct {
-	host     host.Host           // p2p host (optional, may be nil)
-	gater    ConnectionGater     // p2p gater, to ban/unban peers with, may be nil even with p2p enabled
-	connMgr  connmgr.ConnManager // p2p conn manager, to keep a reliable number of peers, may be nil even with p2p enabled
-	dv5Local *enode.LocalNode    // p2p discovery identity (optional, may be nil)
-	dv5Udp   *discover.UDPv5     // p2p discovery service (optional, may be nil)
-	gs       *pubsub.PubSub      // p2p gossip router (optional, may be nil)
-	gsOut    GossipOut           // p2p gossip application interface for publishing (optional, may be nil)
+	host    host.Host           // p2p host (optional, may be nil)
+	gater   ConnectionGater     // p2p gater, to ban/unban peers with, may be nil even with p2p enabled
+	connMgr connmgr.ConnManager // p2p conn manager, to keep a reliable number of peers, may be nil even with p2p enabled
+	// the below components are all optional, and may be nil. They require the host to not be nil.
+	dv5Local *enode.LocalNode // p2p discovery identity
+	dv5Udp   *discover.UDPv5  // p2p discovery service
+	gs       *pubsub.PubSub   // p2p gossip router
+	gsOut    GossipOut        // p2p gossip application interface for publishing
 }
 
 func NewNodeP2P(resourcesCtx context.Context, rollupCfg *rollup.Config, log log.Logger, setup SetupP2P, gossipIn GossipIn) (*NodeP2P, error) {
@@ -46,12 +50,6 @@ func NewNodeP2P(resourcesCtx context.Context, rollupCfg *rollup.Config, log log.
 
 func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.Config, log log.Logger, setup SetupP2P, gossipIn GossipIn) error {
 	var err error
-	// All nil if disabled.
-	n.dv5Local, n.dv5Udp, err = setup.Discovery(log.New("p2p", "discv5"), rollupCfg)
-	if err != nil {
-		return fmt.Errorf("failed to start discv5: %v", err)
-	}
-
 	// nil if disabled.
 	n.host, err = setup.Host(log)
 	if err != nil {
@@ -81,6 +79,17 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.Config, l
 			return fmt.Errorf("failed to join blocks gossip topic: %v", err)
 		}
 		log.Info("started p2p host", "addrs", n.host.Addrs(), "peerID", n.host.ID().Pretty())
+
+		tcpPort, err := FindActiveTCPPort(n.host)
+		if err != nil {
+			log.Warn("failed to find what TCP port p2p is binded to", "err", err)
+		}
+
+		// All nil if disabled.
+		n.dv5Local, n.dv5Udp, err = setup.Discovery(log.New("p2p", "discv5"), rollupCfg, tcpPort)
+		if err != nil {
+			return fmt.Errorf("failed to start discv5: %v", err)
+		}
 	}
 	return nil
 }
@@ -129,4 +138,21 @@ func (n *NodeP2P) Close() error {
 		}
 	}
 	return result.ErrorOrNil()
+}
+
+func FindActiveTCPPort(h host.Host) (uint16, error) {
+	var tcpPort uint16
+	for _, addr := range h.Addrs() {
+		tcpPortStr, err := addr.ValueForProtocol(ma.P_TCP)
+		if err != nil {
+			continue
+		}
+		v, err := strconv.ParseUint(tcpPortStr, 10, 16)
+		if err != nil {
+			continue
+		}
+		tcpPort = uint16(v)
+		break
+	}
+	return tcpPort, nil
 }

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -19,6 +21,10 @@ type Prepared struct {
 }
 
 var _ SetupP2P = (*Prepared)(nil)
+
+func (p *Prepared) TargetPeers() uint {
+	return 20
+}
 
 func (p *Prepared) Check() error {
 	if (p.LocalNode == nil) != (p.UDPv5 == nil) {
@@ -36,6 +42,6 @@ func (p *Prepared) Host(log log.Logger) (host.Host, error) {
 }
 
 // Discovery creates a disc-v5 service. Returns nil, nil, nil if discovery is disabled.
-func (p *Prepared) Discovery(log log.Logger) (*enode.LocalNode, *discover.UDPv5, error) {
+func (p *Prepared) Discovery(log log.Logger, rollupCfg *rollup.Config) (*enode.LocalNode, *discover.UDPv5, error) {
 	return p.LocalNode, p.UDPv5, nil
 }

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ethereum-optimism/optimistic-specs/opnode/rollup"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
@@ -42,6 +44,16 @@ func (p *Prepared) Host(log log.Logger) (host.Host, error) {
 }
 
 // Discovery creates a disc-v5 service. Returns nil, nil, nil if discovery is disabled.
-func (p *Prepared) Discovery(log log.Logger, rollupCfg *rollup.Config) (*enode.LocalNode, *discover.UDPv5, error) {
+func (p *Prepared) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort uint16) (*enode.LocalNode, *discover.UDPv5, error) {
+	if p.LocalNode != nil {
+		dat := OptimismENRData{
+			chainID: rollupCfg.L2ChainID.Uint64(),
+			version: 0,
+		}
+		p.LocalNode.Set(&dat)
+		if tcpPort != 0 {
+			p.LocalNode.Set(enr.TCP(tcpPort))
+		}
+	}
 	return p.LocalNode, p.UDPv5, nil
 }

--- a/op-node/p2p/rpc_server.go
+++ b/op-node/p2p/rpc_server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"time"
 
@@ -26,8 +25,6 @@ import (
 // TODO: dynamic peering
 // - req-resp protocol to ensure peers from a different chain learn they shouldn't be connected
 // - banning peers based on score
-// - store enode in peerstore in dynamic-peering background process
-// - peers must be tagged with the "optimism" tag and marked with high value if the chain ID matches
 
 var (
 	DisabledDiscovery   = errors.New("discovery disabled")
@@ -50,7 +47,6 @@ type Node interface {
 	ConnectionGater() ConnectionGater
 	// ConnectionManager returns the connection manager, to protect peers with, may be nil
 	ConnectionManager() connmgr.ConnManager
-	io.Closer
 }
 
 type APIBackend struct {

--- a/specs/rollup-node-p2p.md
+++ b/specs/rollup-node-p2p.md
@@ -86,10 +86,10 @@ The Ethereum Node Record (ENR) for an Optimism rollup node must contain the foll
 - A UDP port (`udp` field) representing the local discv5 listening port.
 - An Optimism (`optimism` field) L2 network identifier
 
-The `optimism` value is encoded as the concatenation of:
+The `optimism` value is encoded as a single RLP `bytes` value, the concatenation of:
 
-- chain ID (`varint`)
-- fork ID (`varint`)
+- chain ID (`unsigned varint`)
+- fork ID (`unsigned varint`)
 
 Note that DiscV5 is a shared DHT (Distributed Hash Table): the L1 consensus and execution nodes,
 as well as testnet nodes, and even external IOT nodes, all communicate records in this large common DHT.


### PR DESCRIPTION
Implements:
- ENR entry (chain ID and version)
- Background process to do random DHT walk, filter nodes, and add to the peerstore
- Background process to select random, not connected, peers and connect to them
- Discovery test: `A` is the bootnode, `B` and `C` find each other via `A`

